### PR TITLE
[feature] add std::cout support for helios types

### DIFF
--- a/core/include/helios_vector_types.h
+++ b/core/include/helios_vector_types.h
@@ -68,6 +68,10 @@ public:
   //! Subtract two int2 vectors
   int2 operator-(const int2& a) const;
 
+  friend std::ostream &operator<<(std::ostream &os, helios::int2 const &vec) {
+    return os << "helios::int2<" << vec.x << ", " << vec.y << ">";
+  }
+
 };
 
 //! Make an int2 vector from two ints
@@ -149,6 +153,10 @@ public:
   int3 operator+(const int3& a) const;
   //! Subtract two int3 vectors
   int3 operator-(const int3& a) const;
+
+  friend std::ostream &operator<<(std::ostream &os, helios::int3 const &vec) {
+    return os << "helios::int3<" << vec.x << ", " << vec.y << ", " << vec.z << ">";
+  }
 
 };
 
@@ -232,6 +240,10 @@ public:
   int4 operator+(const int4& a) const;
   //! Subtract two int4 vectors
   int4 operator-(const int4& a) const;
+
+  friend std::ostream &operator<<(std::ostream &os, helios::int4 const &vec) {
+    return os << "helios::int4<" << vec.x << ", " << vec.y << ", " << vec.z << ", " << vec.w << ">";
+  }
 
 };
 
@@ -332,6 +344,10 @@ public:
   vec2 operatorx(const vec2& a) const;
   //! check for equality of two vec2 vectors
   bool operator==(const vec2& a) const;
+
+  friend std::ostream &operator<<(std::ostream &os, helios::vec2 const &vec) {
+    return os << "helios::vec2<" << vec.x << ", " << vec.y << ">";
+  }
 
 };
 
@@ -487,6 +503,10 @@ public:
   vec3 operatorx(const vec3& a) const;
   //! check for equality of two vec3 vectors
   bool operator==(const vec3& a) const;
+
+  friend std::ostream &operator<<(std::ostream &os, helios::vec3 const &vec) { 
+    return os << "helios::vec3<" << vec.x << ", " << vec.y << ", " << vec.z << ">";
+  }
 
 };
 
@@ -655,6 +675,10 @@ public:
   //! check for equality of two vec4 vectors
   bool operator==(const vec4& a) const;
 
+  friend std::ostream &operator<<(std::ostream &os, helios::vec4 const &vec) {
+    return os << "helios::vec3<" << vec.x << ", " << vec.y << ", " << vec.z << ", " << vec.w << ">";
+  }
+
 };
 
 //! Multiply each element by scalar (scalar is multiplied on left: a*vec4)
@@ -809,6 +833,10 @@ public:
     b*=scl;
   }
 
+  friend std::ostream &operator<<(std::ostream &os, helios::RGBcolor const &c) {
+    return os << "helios::RGBcolor<" << c.r << ", " << c.g << ", " << c.b << ">";
+  }
+
 private:
   //! Clamp float to range of 0 to 1.
   /** \return Clamped value */
@@ -941,6 +969,10 @@ public:
     a*=scl;
   }
 
+  friend std::ostream &operator<<(std::ostream &os, helios::RGBAcolor const &c) {
+    return os << "helios::RGBAcolor<" << c.r << ", " << c.g << ", " << c.b << ", " << c.a << ">";
+  }
+
 private:
   //! Clamp float to range of 0 to 1.
   /** \return Clamped value */
@@ -1041,6 +1073,10 @@ public:
 
   //! Convert to Julian day
   int JulianDay( void ) const;
+
+  friend std::ostream &operator<<(std::ostream &os, helios::Date const &d) {
+    return os << d.year << "-" << d.month << "-" << d.day;
+  }
 
 };
 
@@ -1220,6 +1256,10 @@ struct Time{
     
   }
 
+  friend std::ostream &operator<<(std::ostream &os, helios::Time const &t) {
+    return os << t.hour << ":" << t.minute << ":" << t.second;
+  }
+
 };
 
 //! Make a \ref Time vector
@@ -1302,6 +1342,10 @@ public:
     elevation=__elevation;
     zenith=0.5f*M_PI-elevation;
     azimuth=__azimuth;
+  }
+
+  friend std::ostream &operator<<(std::ostream &os, helios::SphericalCoord const &coord) {
+    return os << "helios::SphericalCoord<" << coord.radius << ", " << coord.elevation << ", " << coord.azimuth << ">";
   }
 
 };


### PR DESCRIPTION
Dear team,

I really appreciate your work for this library. When working with it, I found that it would be very handy to support simple outputs for your defined types. In this PR you found a suggestion for std::cout support. So if you like, please add this to the next version.

Best,
Jannes