### PR TITLE
added getUniquePrimitiveParentObjectIDs functions

### DIFF
--- a/core/include/Context.h
+++ b/core/include/Context.h
@@ -1689,6 +1689,13 @@ public:
      */
     int selfTest();
     
+    //ERK
+    //! Set seed for random generator
+    /**
+     * \param[in] "seed" uint used to seed the generator
+     */
+    void setSeed(uint seed); 
+    
     //! Mark the Context geometry as ``clean", meaning that the geometry has not been modified since last set as clean
     /** \sa \ref markGeometryDirty(), \ref isGeometryDirty() */
     void markGeometryClean();

--- a/core/include/Context.h
+++ b/core/include/Context.h
@@ -2647,6 +2647,21 @@ public:
      */
     uint getPrimitiveParentObjectID( uint UUID  )const;
     
+    
+    //! Function to return unique parent object IDs for a vector of primitive UUIDs
+    /**
+     * \param[in] "UUIDs" Vector of universal unique identifiers of primitives.
+     */
+    std::vector<uint> getUniquePrimitiveParentObjectIDs(std::vector<uint> UUIDs) const;
+    
+    
+    //! Function to return unique parent object IDs for a vector of primitive UUIDs
+    /**
+     * \param[in] "UUIDs" Vector of universal unique identifiers of primitives.
+     */
+    std::vector<uint> getUniquePrimitiveParentObjectIDs(std::vector<uint> UUIDs, bool include_ObjID_zero) const;
+    
+    
     //! Function to return the surface area of a Primitive
     /** \param[in] "UUID" Universal unique identifier of primitive.
      */

--- a/core/src/Context.cpp
+++ b/core/src/Context.cpp
@@ -13257,6 +13257,38 @@ uint Context::getPrimitiveParentObjectID(uint UUID) const {
     return getPrimitivePointer_private(UUID)->getParentObjectID();
 }
 
+
+std::vector<uint> Context::getUniquePrimitiveParentObjectIDs(std::vector<uint> UUIDs) const {
+    return getUniquePrimitiveParentObjectIDs(UUIDs, false);
+}
+
+
+std::vector<uint> Context::getUniquePrimitiveParentObjectIDs(std::vector<uint> UUIDs, bool include_ObjID_zero) const {
+    
+    //vector of parent object ID for each primitive
+    std::vector<uint> primitiveObjIDs;
+    primitiveObjIDs.resize(UUIDs.size());
+    for(uint i=0;i<UUIDs.size();i++)
+    {
+        primitiveObjIDs.at(i) = getPrimitivePointer_private(UUIDs.at(i))->getParentObjectID();
+    }
+    
+    // sort
+    std::sort(primitiveObjIDs.begin(), primitiveObjIDs.end());
+    
+    // unique
+    auto it = unique(primitiveObjIDs.begin(), primitiveObjIDs.end());
+    primitiveObjIDs.resize(distance(primitiveObjIDs.begin(), it));
+    
+    // remove object ID = 0 from the output if desired and it exisits
+    if(include_ObjID_zero == false & primitiveObjIDs.at(0) == uint(0))
+    {
+        primitiveObjIDs.erase(primitiveObjIDs.begin()); 
+    }
+    
+    return primitiveObjIDs;
+}
+
 float Context::getPrimitiveArea(uint UUID) const {
     return getPrimitivePointer_private(UUID)->getArea();
 }

--- a/core/src/Context.cpp
+++ b/core/src/Context.cpp
@@ -45,6 +45,11 @@ Context::Context(){
 
 }
 
+//ERK
+void Context::setSeed(uint seed){
+    generator.seed(seed);
+}
+
 void Context::addTexture( const char* texture_file ){
     if( textures.find(texture_file)==textures.end() ){//texture has not already been added
         Texture text( texture_file );


### PR DESCRIPTION
This function can be used to easily get the unique parent object IDs for a group of primitives. This is handy when calling loadXML in a loop (for example to read in individual trees) and you want to be able to identify the object IDs associated with each for later use. 

The version of getUniquePrimitiveParentObjectIDs with one input argument by default removes the object ID of zero (no object) from the output if there are non-object primitives. A two argument version allows the user to specify that the object ID of zero should not be removed from output and could be used to check for non-object primitives in a vector of UUIDs. 
