### PR TITLE
2023 03 02 lidar updates

### DIFF
--- a/plugins/lidar/include/LiDAR.h
+++ b/plugins/lidar/include/LiDAR.h
@@ -1057,6 +1057,15 @@ d the last cell's index is Ncells-1.
   */
   void calculateLeafAreaGPU_synthetic( helios::Context* context,  bool beamoutput, bool fillAnalytic );
 
+  //! Calculate the leaf area for each grid volume using equal weighting method
+  /**
+   * \param [in] "beamoutput" if true writes detailed data about each beam to ../beamoutput/beam_data_s_[scan index]_c_[grid cell index].txt.
+   * \param [in] "fillAnalytic" if true, when the iterative LAD inversion fails, the analytic solution using mean dr will be substituted. If false LAD is set to 999.
+   * \note writes voxel level data to ../voxeloutput/voxeloutput.txt
+   */
+  void calculateLeafAreaGPU_equal_weighting( bool beamoutput, bool fillAnalytic );
+  
+  
   // -------- RECONSTRUCTION --------- //
 
   //! Perform a leaf reconstruction based on texture-masked Patches within each gridcell.  The reconstruction produces Patches for each reconstructed leaf surface, with leaf size automatically estimated algorithmically.  

--- a/plugins/lidar/include/LiDAR.h
+++ b/plugins/lidar/include/LiDAR.h
@@ -1022,6 +1022,15 @@ d the last cell's index is Ncells-1.
    * \return (x,y,z) of missing points added to the scan from gapfilling
    */
   std::vector<helios::vec3> gapfillMisses( uint scanID );
+  
+  //! For scans that are missing points (e.g., sky points), this function will attempt to fill in missing points. This increases the accuracy of LAD calculations because it makes sure all pulses are accounted for.
+  /**
+   * \param[in] "scanID" ID of scan to gapfill
+   * \param[in] "gapfill_grid_only" if true, missing points are gapfilled only within the axis-aligned bounding box of the voxel grid. If false missing points are gap filled across the range of phi and theta values specified in the scan xml file.
+   * \return (x,y,z) of missing points added to the scan from gapfilling
+   */
+  std::vector<helios::vec3> gapfillMisses( uint scanID, const bool gapfill_grid_only );
+  
 
   //! Calculate the leaf area for each grid volume
   void calculateLeafAreaGPU();

--- a/plugins/lidar/src/LiDAR.cu
+++ b/plugins/lidar/src/LiDAR.cu
@@ -1659,7 +1659,7 @@ void LiDARcloud::calculateLeafAreaGPU_synthetic( helios::Context* context, bool 
   }
   
   if( !triangulationcomputed ){
-    std::cerr << "ERROR (calculateLeafAreaGPU): Triangulation must be performed prior to leaf area calculation. See triangulateHitPoints()." << std::endl;
+    std::cerr << "ERROR (calculateLeafAreaGPU_synthetic): Triangulation must be performed prior to leaf area calculation. See triangulateHitPoints()." << std::endl;
     exit(EXIT_FAILURE);
   }
   
@@ -1759,7 +1759,7 @@ void LiDARcloud::calculateLeafAreaGPU_synthetic( helios::Context* context, bool 
     }
     
     // create a vector each element of which represents a unique beam and is another vector of the hit point indices of this_scan_xyz that is associated with this beam
-    float previous_beam = 0;
+    float previous_beam = getHitData(this_scan_index[0], "timestamp");
     uint beam_ID = 0;
     std::vector<std::vector<uint>> beam_array(Nbeams);
     for(uint i=0; i < Nhits; i++)
@@ -2296,6 +2296,47 @@ void LiDARcloud::calculateLeafAreaGPU_synthetic( helios::Context* context, bool 
   if( printmessages ){
     std::cout << "finished LAD inversions" << std::endl;
   }
+  
+  for(uint c=0; c<Ncells; c++)
+  {
+    helios::vec3 grid_size = getCellSize(c);
+    helios::vec3 grid_center = getCellCenter(c);
+    
+    if( printmessages ){
+      std::cout << "Cell " << c << ", voxel_beam_count = " << voxel_beam_count_tot[c]  << std::endl;
+      std::cout << "Cell " << c << ", P_first = " << P_first[c] << std::endl;
+      std::cout << "Cell " << c << ", P_sequal = " << P_sequal[c] << std::endl;
+      std::cout << "Cell " << c << ", P_equal = " << P_equal[c] << std::endl;
+      std::cout << "Cell " << c << ", P_intensity = " << P_intensity[c] << std::endl;
+      std::cout << "Cell " << c << ", P_exact = " << P_exact[c] << std::endl;
+      std::cout << "Cell " << c << ", P_ref = " << P_ref[c] << std::endl;
+      
+      std::cout << " " << std::endl;
+      std::cout << "Cell " << c << ", Gref = " << Gtheta_ref[c] << std::endl;
+      std::cout << "Cell " << c << ", Gtri = " << Gtheta[c] << std::endl;
+      std::cout << " " << std::endl;
+    }
+    
+    
+    if( printmessages ){
+      std::cout << "Cell " << c << ", LAD_first = " << LAD_first[c] << std::endl;
+      std::cout << "Cell " << c << ", LAD_equal = " << LAD_equal[c] << std::endl;
+      std::cout << "Cell " << c << ", LAD_intensity = " << LAD_intensity[c] << std::endl;
+      std::cout << "Cell " << c << ", LAD_exact = " << LAD_exact[c] << std::endl;
+      
+      std::cout << " " << std::endl;
+      
+      std::cout << "Cell " << c << ", LAD_first_Gref = " << LAD_first_Gref[c] << std::endl;
+      std::cout << "Cell " << c << ", LAD_equal_Gref = " << LAD_equal_Gref[c] << std::endl;
+      std::cout << "Cell " << c << ", LAD_intensity_Gref = " << LAD_intensity_Gref[c] << std::endl;
+      std::cout << "Cell " << c << ", LAD_exact_Gref = " << LAD_exact_Gref[c] << std::endl;
+      
+      std::cout << "Cell " << c << ", LAD_ref = " <<LA_ref[c]/(grid_size.x*grid_size.y*grid_size.z) << std::endl;
+      
+    }
+  }
+  
+  
   
   // output the voxel level variables
   std::ofstream file_output;

--- a/plugins/lidar/src/LiDAR.cu
+++ b/plugins/lidar/src/LiDAR.cu
@@ -1553,636 +1553,673 @@ void LiDARcloud::calculateLeafAreaGPU_testing( int min_voxel_hits){
 }
 
 void LiDARcloud::calculateLeafAreaGPU_synthetic( helios::Context* context, bool beamoutput, bool fillAnalytic  ){
-    
-    // calculates LAD using several different methods investigated in Kent & Bailey (2021)
-    // writes all voxel level variables to a file
-    // optionally writes detailed information about each beam
-    // unlike previous calculateLeafAreaGPU versions, this one does not set the cell leaf area variable and does not filter based on minVoxelHits argument 
+  
+  // calculates LAD using several different methods investigated in Kent & Bailey (2021)
+  // writes all voxel level variables to a file
+  // optionally writes detailed information about each beam
+  // unlike previous calculateLeafAreaGPU versions, this one does not set the cell leaf area variable and does not filter based on minVoxelHits argument 
+  
+  if( printmessages ){
+    std::cout << "Calculating leaf area..." << std::endl;
+  }
+  
+  if( !triangulationcomputed ){
+    std::cerr << "ERROR (calculateLeafAreaGPU): Triangulation must be performed prior to leaf area calculation. See triangulateHitPoints()." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  
+  if( !hitgridcellcomputed ){
+    calculateHitGridCellGPU();
+  }
+  
+  const uint Nscans = getScanCount();
+  const uint Ncells = getGridCellCount();
+  
+  //variable aggregates over all scans where we just keep tacking hits on the end for all scans
+  std::vector<std::vector<float> > dr_agg; //dr is path length through grid cell
+  dr_agg.resize(Ncells);
+  std::vector<float> G_agg; //G is dot product between ray direction and triangle normal that was hit (only relevant for hits)
+  G_agg.resize(Ncells,0);
+  std::vector<float> hit_before_agg; //hit_before corresponds to scan points that hit something before encountering a particular grid cell
+  hit_before_agg.resize(Ncells,0);
+  std::vector<float> hit_after_agg; //hit_after corresponds to scan points that hit something after encountering a particular grid cell (including something inside that cell)
+  hit_after_agg.resize(Ncells,0);
+  std::vector<float> hit_inside_agg; //hit_inside corresponds to scan points that hit something within a particular grid cell.
+  hit_inside_agg.resize(Ncells,0);
+  
+  //average G(theta)
+  std::vector<float> Gtheta_bar;
+  Gtheta_bar.resize(Ncells,0.f);
+  
+  // nested vectors to save P calculation terms
+  // cell, scan, variable, value
+  std::vector<std::vector<float>>  P_first_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_first_denominator_array(Ncells);
+  
+  std::vector<std::vector<float>>  P_sequal_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_sequal_denominator_array(Ncells);
+  
+  std::vector<std::vector<float>>  P_equal_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_equal_denominator_array(Ncells);
+  
+  std::vector<std::vector<float>>  P_ideal_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_ideal_denominator_array(Ncells);
+  
+  std::vector<std::vector<float>>  P_intensity_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_intensity_denominator_array(Ncells);
+  
+  std::vector<std::vector<float>>  P_exact_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_exact_denominator_array(Ncells);
+  
+  std::vector<std::vector<uint>>  voxel_beam_count_array(Ncells);
+  
+  
+  std::vector<std::vector<float>>  dr_array(Ncells);
+  
+  
+  // r is the index of all hitpoints (all scans)
+  // it is saved for the current scan in this_scan_index
+  // i is the index of this_scan_index
+  // so when accessing the things using getHitData(), getHitXYZ(), etc, 
+  // for only one of the scans (this_scan), 
+  // need to use getHitData(this_scan_index[i]) not getHitData(i)
+  
+  ////////////// We are going to perform all calculations on a scan-by-scan basis: loop through each scan
+  for( uint s=0; s<Nscans; s++ ){
     
     if( printmessages ){
-        std::cout << "Calculating leaf area..." << std::endl;
+      std::cout << "------------------------SCAN = " << s << std::endl;
     }
     
-    if( !triangulationcomputed ){
-        std::cerr << "ERROR (calculateLeafAreaGPU): Triangulation must be performed prior to leaf area calculation. See triangulateHitPoints()." << std::endl;
-        exit(EXIT_FAILURE);
-    }
-    
-    if( !hitgridcellcomputed ){
-      calculateHitGridCellGPU();
-    }
-    
-    const uint Nscans = getScanCount();
-    const uint Ncells = getGridCellCount();
-    
-    //variable aggregates over all scans where we just keep tacking hits on the end for all scans
-    std::vector<std::vector<float> > dr_agg; //dr is path length through grid cell
-    dr_agg.resize(Ncells);
-    std::vector<float> G_agg; //G is dot product between ray direction and triangle normal that was hit (only relevant for hits)
-    G_agg.resize(Ncells,0);
-    std::vector<float> hit_before_agg; //hit_before corresponds to scan points that hit something before encountering a particular grid cell
-    hit_before_agg.resize(Ncells,0);
-    std::vector<float> hit_after_agg; //hit_after corresponds to scan points that hit something after encountering a particular grid cell (including something inside that cell)
-    hit_after_agg.resize(Ncells,0);
-    std::vector<float> hit_inside_agg; //hit_inside corresponds to scan points that hit something within a particular grid cell.
-    hit_inside_agg.resize(Ncells,0);
-    
-    //average G(theta)
-    std::vector<float> Gtheta_bar;
-    Gtheta_bar.resize(Ncells,0.f);
-    
-    // nested vectors to save P calculation terms
-    // cell, scan, variable, value
-    std::vector<std::vector<float>>  P_first_numerator_array(Ncells);
-    std::vector<std::vector<float>>  P_first_denominator_array(Ncells);
-    
-    std::vector<std::vector<float>>  P_sequal_numerator_array(Ncells);
-    std::vector<std::vector<float>>  P_sequal_denominator_array(Ncells);
-    
-    std::vector<std::vector<float>>  P_equal_numerator_array(Ncells);
-    std::vector<std::vector<float>>  P_equal_denominator_array(Ncells);
-    
-    std::vector<std::vector<float>>  P_intensity_numerator_array(Ncells);
-    std::vector<std::vector<float>>  P_intensity_denominator_array(Ncells);
-    
-    std::vector<std::vector<float>>  P_exact_numerator_array(Ncells);
-    std::vector<std::vector<float>>  P_exact_denominator_array(Ncells);
-    
-    std::vector<std::vector<uint>>  voxel_beam_count_array(Ncells);
-    
-    
-    std::vector<std::vector<float>>  dr_array(Ncells);
-    
-    
-    // r is the index of all hitpoints (all scans)
-    // it is saved for the current scan in this_scan_index
-    // i is the index of this_scan_index
-    // so when accessing the things using getHitData(), getHitXYZ(), etc, 
-    // for only one of the scans (this_scan), 
-    // need to use getHitData(this_scan_index[i]) not getHitData(i)
-    
-    ////////////// We are going to perform all calculations on a scan-by-scan basis: loop through each scan
-    for( uint s=0; s<Nscans; s++ ){
-        
-        if( printmessages ){
-            std::cout << "------------------------SCAN = " << s << std::endl;
-        }
-        
-        //only work with hitpoints assoicated with current scan
-        std::vector<helios::vec3> this_scan_xyz;
-        std::vector<uint> this_scan_index;
-        for( size_t r=0; r< getHitCount(); r++ ){
-            if( getHitScanID(r)==s ){
-                this_scan_xyz.push_back( getHitXYZ(r) );
-                this_scan_index.push_back(r);
-            }
-        }
-        // size of the array of all the hits in this scan
-        size_t Nhits = this_scan_xyz.size();
-        
-        if( printmessages ){
-            std::cout << "Number of hitpoints associated with this scan = Nhits = " << Nhits << std::endl;
-        }
-        
-        // count the number of beams (i.e. don't count multiple hits per beam)
-        float previous_time = -1.f;
-        uint Nbeams = 0;
-        for(uint i=0; i < Nhits; i++)
-        {
-            float current_time = getHitData(this_scan_index[i], "timestamp");
-            if(current_time != previous_time){
-                Nbeams ++;
-                previous_time = current_time;
-            }
-        }
-        
-        if( printmessages ){
-            std::cout << "Number of beams associated with this scan = Nbeams = " << Nbeams << std::endl;
-        }
-        
-        // create a vector each element of which represents a unique beam and is another vector of the hit point indices of this_scan_xyz that is associated with this beam
-        float previous_beam = 0;
-        uint beam_ID = 0;
-        std::vector<std::vector<uint>> beam_array(Nbeams);
-        for(uint i=0; i < Nhits; i++)
-        {
-            float current_beam = getHitData(this_scan_index[i], "timestamp");
-            
-            if(current_beam == previous_beam)
-            {
-                beam_array.at(beam_ID).push_back(i); //ERK 
-            }else{
-                beam_ID ++;
-                beam_array.at(beam_ID).push_back(i); //ERK
-                previous_beam = current_beam;
-            }
-            
-        }
-        
-        // set up GPU things for current scan
-        const float3 origin = vec3tofloat3(getScanOrigin(s));
-        float3* scan_xyz = (float3*)malloc( Nhits*sizeof(float3) );
-        float* scan_weight = (float*)malloc( Nhits*sizeof(float) );
-        
-        for( size_t i=0; i<Nhits; i++ ){
-            scan_xyz[i] = vec3tofloat3(this_scan_xyz.at(i));
-            scan_weight[i] = 1.f;
-        }
-        
-        float* hit_before = (float*)malloc( sizeof(float));
-        float* hit_after = (float*)malloc( sizeof(float));
-        float* d_hit_before;
-        CUDA_CHECK_ERROR( cudaMalloc((float**)&d_hit_before, sizeof(float)) );
-        float* d_hit_after;
-        CUDA_CHECK_ERROR( cudaMalloc((float**)&d_hit_after, sizeof(float)) );
-        
-        float3* d_scan_xyz;
-        CUDA_CHECK_ERROR( cudaMalloc((float3**)&d_scan_xyz, Nhits*sizeof(float3)) );
-        CUDA_CHECK_ERROR( cudaMemcpy(d_scan_xyz, scan_xyz, Nhits*sizeof(float3), cudaMemcpyHostToDevice) );
-        
-        float* d_scan_weight;
-        CUDA_CHECK_ERROR( cudaMalloc((float**)&d_scan_weight, Nhits*sizeof(float)) );
-        CUDA_CHECK_ERROR( cudaMemcpy(d_scan_weight, scan_weight, Nhits*sizeof(float), cudaMemcpyHostToDevice) );
-        
-        float* dr = (float*)malloc( Nhits*sizeof(float));
-        float* d_dr;
-        CUDA_CHECK_ERROR( cudaMalloc((float**)&d_dr, Nhits*sizeof(float)) );
-        
-        uint* hit_location = (uint*)malloc( Nhits*sizeof(uint));
-        uint* d_hit_location;
-        CUDA_CHECK_ERROR( cudaMalloc((uint**)&d_hit_location, Nhits*sizeof(uint)) );
-        
-        
-        /////////////////////////////////////////////////////////////////////
-        // now loop through each voxel
-        for( uint c=0; c<Ncells; c++ ){
-            
-            if( printmessages ){
-                std::cout << "----CELL = " << c << std::endl;
-            }
-            
-            std::ofstream file_beam;
-            if( beamoutput){
-                // set up header of file that outputs one row for each beam in the current scan that interacts with the current voxel
-                
-                file_beam.open("../beamoutput/beam_data_s_" + std::to_string(s) + "_c_" + std::to_string(c) + ".txt");
-                file_beam << "scan, cell, beam, R_before, R_inside, R_after, R_miss, E_before, E_inside, E_after, E_miss, sin_theta, dr, last_dr"  << std::endl;
-            }
-            
-            //load the attributes of the grid cell
-            float3 center = vec3tofloat3(getCellCenter(c));
-            float3 anchor = vec3tofloat3(getCellGlobalAnchor(c));
-            float3 size = vec3tofloat3(getCellSize(c));
-            float rotation = getCellRotation(c);
-            
-            CUDA_CHECK_ERROR( cudaMemset( d_hit_location, 0, Nhits*sizeof(uint)) );
-            CUDA_CHECK_ERROR( cudaMemset( d_dr, 0, Nhits*sizeof(float)) );
-            CUDA_CHECK_ERROR( cudaMemset( d_hit_before, 0, sizeof(float)) );
-            CUDA_CHECK_ERROR( cudaMemset( d_hit_after, 0, sizeof(float)) );
-            
-            uint3 dimBlock = make_uint3( min(size_t(512),Nhits), 1, 1 );
-            uint3 dimGrid = make_uint3( ceil(float(Nhits)/dimBlock.x), 1, 1  );
-            
-            if( dimBlock.x==0 && dimGrid.x==0 ){
-                continue;
-            }
-            
-            float scanner_range = 5000.0;
-            intersectGridcell_synthetic <<< dimGrid, dimBlock >>>( Nhits, origin, d_scan_xyz, d_scan_weight, center, anchor, size, rotation, d_dr, d_hit_before, d_hit_after, d_hit_location, scanner_range );
-            
-            cudaDeviceSynchronize();
-            CUDA_CHECK_ERROR( cudaPeekAtLastError() ); //if there was an error inside the kernel, it will show up here
-            
-            //copy results back to host
-            CUDA_CHECK_ERROR( cudaMemcpy( hit_before, d_hit_before, sizeof(float), cudaMemcpyDeviceToHost));
-            CUDA_CHECK_ERROR( cudaMemcpy( hit_after, d_hit_after, sizeof(float), cudaMemcpyDeviceToHost));
-            CUDA_CHECK_ERROR( cudaMemcpy( dr, d_dr, Nhits*sizeof(float), cudaMemcpyDeviceToHost));
-            CUDA_CHECK_ERROR( cudaMemcpy( hit_location, d_hit_location, Nhits*sizeof(uint), cudaMemcpyDeviceToHost));
-            
-            float P_first_numerator = 0;
-            float P_first_denominator = 0;
-            float P_sequal_numerator = 0;
-            float P_sequal_denominator = 0;
-            float P_equal_numerator = 0;
-            float P_equal_denominator = 0;
-            float P_intensity_numerator = 0;
-            float P_intensity_denominator = 0;
-            float P_exact_numerator = 0;
-            float P_exact_denominator = 0;
-            uint voxel_beam_count = 0;
-            
-            if( printmessages ){
-                std::cout << "Nbeams = " << Nbeams << std::endl;
-            }
-            ////////////////////////// loop through each beam associated with the current scan
-            for(int k = 0; k < Nbeams; k++){
-                
-                float R_before = 0;
-                float R_inside = 0;
-                float R_after = 0;
-                float R_miss = 0;
-                
-                float E_before = 0;
-                float E_inside = 0;
-                float E_after = 0;
-                float E_miss = 0;
-                
-                float sin_theta;
-                float W = 0;
-                float drr = 0;
-                float last_drr = 0;
-                
-                ////////// loop through the hitpoints in the current beam to get number of rays in each location
-                for(int j = 0; j < beam_array.at(k).size(); j++){
-                    
-                    // pull out the index of the current scan's current beam's current hit (which is used to access the overall hit index r through this_scan_index[i])
-                    uint i = beam_array.at(k).at(j);
-                    
-                    helios::vec3 direction = getHitXYZ(this_scan_index[i])-getScanOrigin(getHitScanID(this_scan_index[i]));
-                    direction.normalize();
-                    sin_theta = sin(acos_safe(direction.z));
-                    
-                    last_drr = dr[i];
-                    drr += dr[i];
-                    
-                    if(hit_location[i] == 1){
-                        R_before = R_before +  getHitData(this_scan_index[i], "nRaysHit");
-                        E_before ++;
-                    }else if(hit_location[i] == 2){
-                        R_inside = R_inside +  getHitData(this_scan_index[i], "nRaysHit");
-                        E_inside ++;
-                    }else if(hit_location[i] == 3){
-                        R_after = R_after +  getHitData(this_scan_index[i], "nRaysHit");
-                        E_after ++;
-                        if(getHitData(this_scan_index[i], "target_index") == 0){ // if this is the first hitpoint for this beam,
-                            W = 1.0;
-                        }
-                    }else if(hit_location[i] == 4){
-                        R_miss = R_miss +  getHitData(this_scan_index[i], "nRaysHit");
-                        E_miss ++;
-                    } // or this hitpoint / beam did not intersect the voxel and should not be added to the total number of beams for this voxel
-                    
-                } // end of loop through each hit in the current beam
-                
-                // calculate the average dr across all hitpoints for the beam (they should all be the same anyway... but just in case)
-                float drrx = drr / float(beam_array.at(k).size());
-                
-                // if the path length is greater than 0 (it passes throught the current voxel), save it as an element of
-                if( drrx > 0.f )
-                {
-                    dr_array.at(c).push_back(drrx);
-                }
-                
-                if( beamoutput ){
-                    // output info about the current beam to file
-                    file_beam << s << "," << c << "," << k << "," << R_before << "," << R_inside << "," << R_after << "," << R_miss << "," << E_before << "," << E_inside << "," << E_after << "," << E_miss << "," << sin_theta << "," << drrx << "," << last_drr << std::endl;
-                }
-                
-                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                // calculate terms for different P methods
-                
-                // P_exact
-                if(R_inside != 0 || R_after != 0 || R_miss != 0){ // only count this beam for P_exact if some energy made it to the voxel
-                    P_exact_numerator += ((R_after + R_miss) / (R_before + R_inside + R_after + R_miss))*sin_theta;
-                    P_exact_denominator += ((R_inside + R_after + R_miss) / (R_before + R_inside + R_after + R_miss))*sin_theta;
-                    voxel_beam_count++;
-                }
-                
-                // P_intensity
-                if(R_inside != 0 || R_after != 0){ // only count this beam for P_intensity if some energy hit inside or after the voxel (not including misses)
-                    P_intensity_numerator += (R_after / (R_before + R_inside + R_after))*sin_theta;
-                    P_intensity_denominator += ((R_inside + R_after) / (R_before + R_inside + R_after))*sin_theta;
-                }else if(R_inside == 0 && R_after == 0 && R_before == 0 && R_miss != 0){ // also count this beam if all the energy missed (but still went throught the voxel)
-                    P_intensity_numerator += 1*sin_theta;
-                    P_intensity_denominator += 1*sin_theta;
-                }
-                
-                // P_equal
-                if(E_inside != 0 || E_after != 0){ // only count for P_equal if some hit points were inside or after the voxel
-                    P_equal_numerator += (E_after / (E_before + E_inside + E_after))*sin_theta;
-                    P_equal_denominator += ((E_inside + E_after) / (E_before + E_inside + E_after))*sin_theta;
-                }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
-                    P_equal_numerator += 1*sin_theta;
-                    P_equal_denominator += 1*sin_theta;
-                }
-                
-                // P_sequal
-                if(E_inside != 0 || E_after != 0){ // only count for P_sequal if some hit points were inside or after the voxel
-                    P_sequal_numerator += E_after / (E_inside + E_after);
-                    P_sequal_denominator += 1;
-                }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
-                    P_sequal_numerator += 1;
-                    P_sequal_denominator += 1;
-                }
-                
-                // P_first
-                if(E_before == 0 && (E_inside != 0 || E_after != 0)){ // only count for P_sequal if some hit points were inside or after the voxel
-                    P_first_numerator += W*sin_theta;
-                    P_first_denominator += 1*sin_theta;
-                }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
-                    P_first_numerator += 1*sin_theta;
-                    P_first_denominator += 1*sin_theta;
-                }
-                
-                
-            }// end of loop through all beams for the current cell
-            
-            // save results for the current cell to the arrays
-            
-            P_first_numerator_array.at(c).push_back(P_first_numerator);
-            P_first_denominator_array.at(c).push_back(P_first_denominator);
-            
-            P_sequal_numerator_array.at(c).push_back(P_sequal_numerator);
-            P_sequal_denominator_array.at(c).push_back(P_sequal_denominator);
-            
-            P_equal_numerator_array.at(c).push_back(P_equal_numerator);
-            P_equal_denominator_array.at(c).push_back(P_equal_denominator);
-            
-            P_intensity_numerator_array.at(c).push_back(P_intensity_numerator);
-            P_intensity_denominator_array.at(c).push_back(P_intensity_denominator);
-            
-            P_exact_numerator_array.at(c).push_back(P_exact_numerator);
-            P_exact_denominator_array.at(c).push_back(P_exact_denominator);
-            
-            voxel_beam_count_array.at(c).push_back(voxel_beam_count);
-            
-            hit_before_agg.at(c) += *hit_before;
-            hit_after_agg.at(c) += *hit_after;
-            
-            for( size_t i=0; i<Nhits; i++ ){
-                if( dr[i]>0.f ){
-                    dr_agg.at(c).push_back(dr[i]);
-                }
-            }
-            
-            file_beam.close();
-        } // end of loop through all cells
-        
-        free( scan_xyz );
-        free( scan_weight );
-        free( dr );
-        free( hit_before );
-        free( hit_after );
-        CUDA_CHECK_ERROR( cudaFree(d_scan_xyz) );
-        CUDA_CHECK_ERROR( cudaFree(d_scan_weight) );
-        CUDA_CHECK_ERROR( cudaFree(d_dr) );
-        CUDA_CHECK_ERROR( cudaFree(d_hit_before) );
-        CUDA_CHECK_ERROR( cudaFree(d_hit_after) );
-        
-    }//end scan loop
-    
-    std::vector<float> P_first(Ncells);
-    std::vector<float> P_sequal(Ncells);
-    std::vector<float> P_equal(Ncells);
-    std::vector<float> P_intensity(Ncells);
-    std::vector<float> P_exact(Ncells);
-    std::vector<uint> voxel_beam_count_tot(Ncells);
-    std::vector<float> dr_bar(Ncells);
-    
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // now aggregate over all scans
-    for( uint c=0; c<Ncells; c++ ){
-        
-        float P_first_numerator_array_agg = 0;
-        float P_first_denominator_array_agg = 0;
-        
-        float P_sequal_numerator_array_agg = 0;
-        float P_sequal_denominator_array_agg = 0;
-        
-        float P_equal_numerator_array_agg = 0;
-        float P_equal_denominator_array_agg = 0;
-        
-        float P_intensity_numerator_array_agg= 0;
-        float P_intensity_denominator_array_agg= 0;
-        
-        float P_exact_numerator_array_agg= 0;
-        float P_exact_denominator_array_agg= 0;
-        
-        uint voxel_beam_count_array_agg=0;
-        
-        
-        for( uint s=0; s<Nscans; s++ ){
-            
-            P_first_numerator_array_agg += P_first_numerator_array.at(c).at(s);
-            P_first_denominator_array_agg += P_first_denominator_array.at(c).at(s);
-            
-            P_sequal_numerator_array_agg += P_sequal_numerator_array.at(c).at(s);
-            P_sequal_denominator_array_agg += P_sequal_denominator_array.at(c).at(s);
-            
-            P_equal_numerator_array_agg += P_equal_numerator_array.at(c).at(s);
-            P_equal_denominator_array_agg += P_equal_denominator_array.at(c).at(s);
-            
-            P_intensity_numerator_array_agg += P_intensity_numerator_array.at(c).at(s);
-            P_intensity_denominator_array_agg += P_intensity_denominator_array.at(c).at(s);
-            
-            P_exact_numerator_array_agg += P_exact_numerator_array.at(c).at(s);
-            P_exact_denominator_array_agg += P_exact_denominator_array.at(c).at(s);
-            voxel_beam_count_array_agg += voxel_beam_count_array.at(c).at(s);
-        }
-        
-        
-        P_first[c] = P_first_numerator_array_agg / P_first_denominator_array_agg ;
-        P_sequal[c] = P_sequal_numerator_array_agg / P_sequal_denominator_array_agg ;
-        P_equal[c] = P_equal_numerator_array_agg / P_equal_denominator_array_agg ;
-        P_intensity[c] = P_intensity_numerator_array_agg / P_intensity_denominator_array_agg ;
-        P_exact[c] = P_exact_numerator_array_agg / P_exact_denominator_array_agg ;
-        voxel_beam_count_tot[c] = voxel_beam_count_array_agg;
-        if( printmessages ){
-            std::cout << "Cell " << c << ", voxel_beam_count = " << voxel_beam_count_tot[c]  << std::endl;
-            std::cout << "Cell " << c << ", P_first = " << P_first[c] << std::endl;
-            std::cout << "Cell " << c << ", P_sequal = " << P_sequal[c] << std::endl;
-            std::cout << "Cell " << c << ", P_equal = " << P_equal[c] << std::endl;
-            std::cout << "Cell " << c << ", P_intensity = " << P_intensity[c] << std::endl;
-            std::cout << "Cell " << c << ", P_exact = " << P_exact[c] << std::endl;
-        }
-        
-        float mean_dr = 0;
-        for(int j = 0; j < dr_array.at(c).size(); j++)
-        {
-            mean_dr += dr_array.at(c).at(j);
-        }
-        dr_bar[c] = mean_dr/ float(dr_array.at(c).size());
-        if( printmessages ){
-            std::cout << "Cell " << c << ", dr_bar = " <<  dr_bar[c] << std::endl;
-        }
-    } //end of loop through cells to aggregate all scans
-    
-    
-    /// old code in original calculateLeafAreaGPU_testing() ... do we need to keep this??
-    //----------- Calculate number of hits in voxels -------------- //
-    
-    //figure out hits for all scans
+    //only work with hitpoints assoicated with current scan
+    std::vector<helios::vec3> this_scan_xyz;
+    std::vector<uint> this_scan_index;
     for( size_t r=0; r< getHitCount(); r++ ){
-        if( getHitGridCell(r)>=0 ){
-            helios::vec3 direction = getHitXYZ(r)-getScanOrigin(getHitScanID(r));
-            direction.normalize();
-            hit_inside_agg.at(getHitGridCell(r)) += sin(acos_safe(direction.z));
-        }
+      if( getHitScanID(r)==s ){
+        this_scan_xyz.push_back( getHitXYZ(r) );
+        this_scan_index.push_back(r);
+      }
+    }
+    // size of the array of all the hits in this scan
+    size_t Nhits = this_scan_xyz.size();
+    
+    if( printmessages ){
+      std::cout << "Number of hitpoints associated with this scan = Nhits = " << Nhits << std::endl;
     }
     
-    //---------------------- Calculate G(theta) from triangulation --------------------------//
-    
-    std::vector<float> Gtheta;
-    Gtheta.resize(Ncells,0.f);
-    
-    const size_t Ntri = getTriangleCount();
-    
-    std::vector<uint> cell_tri_count;
-    cell_tri_count.resize(Ncells,0);
-    
-    std::vector<float> area_sin_sum;
-    area_sin_sum.resize(Ncells,0.f);
-    
-    for( size_t t=0; t<Ntri; t++ ){
-        
-        Triangulation tri = getTriangle(t);
-        
-        int cell = tri.gridcell;
-        
-        if( cell>=0 && cell<Ncells ){ //triangle is inside a grid cell
-            
-            helios::vec3 t0 = tri.vertex0;
-            helios::vec3 t1 = tri.vertex1;
-            helios::vec3 t2 = tri.vertex2;
-            
-            helios::vec3 v0 = t1-t0;
-            helios::vec3 v1 = t2-t0;
-            helios::vec3 v2 = t2-t1;
-            
-            float L0 = v0.magnitude();
-            float L1 = v1.magnitude();
-            float L2 = v2.magnitude();
-            
-            float S = 0.5f*(L0+L1+L2);
-            float area = sqrt( S*(S-L0)*(S-L1)*(S-L2) );
-            
-            helios::vec3 normal = cross( v0, v2 );
-            normal.normalize();
-            
-            helios::vec3 raydir = t0-getScanOrigin( tri.scanID );
-            raydir.normalize();
-            
-            float theta = fabs(acos_safe(raydir.z));
-            
-            if( area==area ){ //in rare cases you can get area=NaN
-                
-                Gtheta.at(cell) += fabs(normal*raydir)*area*fabs(sin(theta));
-                
-                area_sin_sum.at(cell) += area*fabs(sin(theta));
-                cell_tri_count.at(cell) += 1;
-                
-            }
-            
-        }
+    // count the number of beams (i.e. don't count multiple hits per beam)
+    float previous_time = -1.f;
+    uint Nbeams = 0;
+    for(uint i=0; i < Nhits; i++)
+    {
+      float current_time = getHitData(this_scan_index[i], "timestamp");
+      if(current_time != previous_time){
+        Nbeams ++;
+        previous_time = current_time;
+      }
     }
     
+    if( printmessages ){
+      std::cout << "Number of beams associated with this scan = Nbeams = " << Nbeams << std::endl;
+    }
+    
+    // create a vector each element of which represents a unique beam and is another vector of the hit point indices of this_scan_xyz that is associated with this beam
+    float previous_beam = 0;
+    uint beam_ID = 0;
+    std::vector<std::vector<uint>> beam_array(Nbeams);
+    for(uint i=0; i < Nhits; i++)
+    {
+      float current_beam = getHitData(this_scan_index[i], "timestamp");
+      
+      if(current_beam == previous_beam)
+      {
+        beam_array.at(beam_ID).push_back(i); //ERK 
+      }else{
+        beam_ID ++;
+        beam_array.at(beam_ID).push_back(i); //ERK
+        previous_beam = current_beam;
+      }
+      
+    }
+    
+    // set up GPU things for current scan
+    const float3 origin = vec3tofloat3(getScanOrigin(s));
+    float3* scan_xyz = (float3*)malloc( Nhits*sizeof(float3) );
+    float* scan_weight = (float*)malloc( Nhits*sizeof(float) );
+    
+    for( size_t i=0; i<Nhits; i++ ){
+      scan_xyz[i] = vec3tofloat3(this_scan_xyz.at(i));
+      scan_weight[i] = 1.f;
+    }
+    
+    float* hit_before = (float*)malloc( sizeof(float));
+    float* hit_after = (float*)malloc( sizeof(float));
+    float* d_hit_before;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_hit_before, sizeof(float)) );
+    float* d_hit_after;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_hit_after, sizeof(float)) );
+    
+    float3* d_scan_xyz;
+    CUDA_CHECK_ERROR( cudaMalloc((float3**)&d_scan_xyz, Nhits*sizeof(float3)) );
+    CUDA_CHECK_ERROR( cudaMemcpy(d_scan_xyz, scan_xyz, Nhits*sizeof(float3), cudaMemcpyHostToDevice) );
+    
+    float* d_scan_weight;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_scan_weight, Nhits*sizeof(float)) );
+    CUDA_CHECK_ERROR( cudaMemcpy(d_scan_weight, scan_weight, Nhits*sizeof(float), cudaMemcpyHostToDevice) );
+    
+    float* dr = (float*)malloc( Nhits*sizeof(float));
+    float* d_dr;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_dr, Nhits*sizeof(float)) );
+    
+    uint* hit_location = (uint*)malloc( Nhits*sizeof(uint));
+    uint* d_hit_location;
+    CUDA_CHECK_ERROR( cudaMalloc((uint**)&d_hit_location, Nhits*sizeof(uint)) );
+    
+    
+    /////////////////////////////////////////////////////////////////////
+    // now loop through each voxel
     for( uint c=0; c<Ncells; c++ ){
-        if( cell_tri_count[c]>0 ){
-            //Gtheta[c] *= float(cell_tri_count[c])/(area_sum[c]*sin_sum[c]);
-            //Gtheta[c] *= float(cell_tri_count[c])/(area_sin_sum[c]);
-            Gtheta[c] *= 1.0/(area_sin_sum[c]);
-            
-            Gtheta_bar[c] += Gtheta[c]/float(Nscans);
-        }
-    }
-    
-    
-    //------------------Calculate "Reference" P and also mean and variance of dr --------------------//
-    // this is the value of P calculated using the reference values of LAD and Gtheta (from calculateSyntheticLeafArea, calculateSyntheticGtheta),
-    // and the path length from all beams for a given cell
-    
-    // first get the reference LA and Gtheta using modified functions that save output to arrays
-    std::vector<float> LA_ref = calculateSyntheticLeafArea(context);
-    std::vector<float> Gtheta_ref = calculateSyntheticGtheta(context);
-    
-    std::vector<float> P_ref(Ncells);
-    P_ref.resize(Ncells,0.f);
-    
-    std::vector<float> dr_bar_ref(Ncells);
-    dr_bar_ref.resize(Ncells,0.f);
-    
-    std::vector<float> dr_var_ref(Ncells);
-    dr_var_ref.resize(Ncells,0.f);
-    
-    for(uint c=0; c<Ncells; c++)
-    {
-        helios::vec3 gridsize = getCellSize(c);
-        float LAD_ref = LA_ref.at(c) / (gridsize.x*gridsize.y*gridsize.z);
-        float G_ref = Gtheta_ref.at(c);
+      
+      if( printmessages ){
+        std::cout << "----CELL = " << c << std::endl;
+      }
+      
+      std::ofstream file_beam;
+      if( beamoutput){
+        // set up header of file that outputs one row for each beam in the current scan that interacts with the current voxel
         
-        float dr_bar_tmp = 0;
-        float sum_term = 0;
-        for(uint j=0; j<dr_array.at(c).size(); j++)
+        file_beam.open("../beamoutput/beam_data_s_" + std::to_string(s) + "_c_" + std::to_string(c) + ".txt");
+        file_beam << "scan, cell, beam, R_before, R_inside, R_after, R_miss, E_before, E_inside, E_after, E_miss, sin_theta, dr, last_dr, I_before, I_inside, I_after, I_miss"  << std::endl;
+      }
+      
+      //load the attributes of the grid cell
+      float3 center = vec3tofloat3(getCellCenter(c));
+      float3 anchor = vec3tofloat3(getCellGlobalAnchor(c));
+      float3 size = vec3tofloat3(getCellSize(c));
+      float rotation = getCellRotation(c);
+      
+      CUDA_CHECK_ERROR( cudaMemset( d_hit_location, 0, Nhits*sizeof(uint)) );
+      CUDA_CHECK_ERROR( cudaMemset( d_dr, 0, Nhits*sizeof(float)) );
+      CUDA_CHECK_ERROR( cudaMemset( d_hit_before, 0, sizeof(float)) );
+      CUDA_CHECK_ERROR( cudaMemset( d_hit_after, 0, sizeof(float)) );
+      
+      uint3 dimBlock = make_uint3( min(size_t(512),Nhits), 1, 1 );
+      uint3 dimGrid = make_uint3( ceil(float(Nhits)/dimBlock.x), 1, 1  );
+      
+      if( dimBlock.x==0 && dimGrid.x==0 ){
+        continue;
+      }
+      
+      float scanner_range = 5000.0;
+      intersectGridcell_synthetic <<< dimGrid, dimBlock >>>( Nhits, origin, d_scan_xyz, d_scan_weight, center, anchor, size, rotation, d_dr, d_hit_before, d_hit_after, d_hit_location, scanner_range );
+      
+      cudaDeviceSynchronize();
+      CUDA_CHECK_ERROR( cudaPeekAtLastError() ); //if there was an error inside the kernel, it will show up here
+      
+      //copy results back to host
+      CUDA_CHECK_ERROR( cudaMemcpy( hit_before, d_hit_before, sizeof(float), cudaMemcpyDeviceToHost));
+      CUDA_CHECK_ERROR( cudaMemcpy( hit_after, d_hit_after, sizeof(float), cudaMemcpyDeviceToHost));
+      CUDA_CHECK_ERROR( cudaMemcpy( dr, d_dr, Nhits*sizeof(float), cudaMemcpyDeviceToHost));
+      CUDA_CHECK_ERROR( cudaMemcpy( hit_location, d_hit_location, Nhits*sizeof(uint), cudaMemcpyDeviceToHost));
+      
+      float P_first_numerator = 0;
+      float P_first_denominator = 0;
+      float P_sequal_numerator = 0;
+      float P_sequal_denominator = 0;
+      float P_equal_numerator = 0;
+      float P_equal_denominator = 0;
+      float P_intensity_numerator = 0;
+      float P_intensity_denominator = 0;
+      float P_ideal_numerator = 0;
+      float P_ideal_denominator = 0;
+      float P_exact_numerator = 0;
+      float P_exact_denominator = 0;
+      uint voxel_beam_count = 0;
+      
+      if( printmessages ){
+        std::cout << "Nbeams = " << Nbeams << std::endl;
+      }
+      ////////////////////////// loop through each beam associated with the current scan
+      for(int k = 0; k < Nbeams; k++){
+        
+        float R_before = 0;
+        float R_inside = 0;
+        float R_after = 0;
+        float R_miss = 0;
+        
+        float I_before = 0;
+        float I_inside = 0;
+        float I_after = 0;
+        float I_miss = 0;
+        
+        float E_before = 0;
+        float E_inside = 0;
+        float E_after = 0;
+        float E_miss = 0;
+        
+        float sin_theta;
+        float W = 0;
+        float drr = 0;
+        float last_drr = 0;
+        
+        ////////// loop through the hitpoints in the current beam to get number of rays in each location
+        for(int j = 0; j < beam_array.at(k).size(); j++){
+          
+          // pull out the index of the current scan's current beam's current hit (which is used to access the overall hit index r through this_scan_index[i])
+          uint i = beam_array.at(k).at(j);
+          
+          helios::vec3 direction = getHitXYZ(this_scan_index[i])-getScanOrigin(getHitScanID(this_scan_index[i]));
+          direction.normalize();
+          sin_theta = sin(acos_safe(direction.z));
+          
+          last_drr = dr[i];
+          drr += dr[i];
+          
+          if(hit_location[i] == 1){
+            R_before = R_before +  getHitData(this_scan_index[i], "nRaysHit");
+            I_before = I_before + getHitData(this_scan_index[i], "intensity");
+            E_before ++;
+          }else if(hit_location[i] == 2){
+            R_inside = R_inside +  getHitData(this_scan_index[i], "nRaysHit");
+            I_inside = I_inside + getHitData(this_scan_index[i], "intensity");
+            E_inside ++;
+          }else if(hit_location[i] == 3){
+            R_after = R_after +  getHitData(this_scan_index[i], "nRaysHit");
+            I_after = I_after + getHitData(this_scan_index[i], "intensity");
+            E_after ++;
+            if(getHitData(this_scan_index[i], "target_index") == 0){ // if this is the first hitpoint for this beam,
+              W = 1.0;
+            }
+          }else if(hit_location[i] == 4){
+            R_miss = R_miss +  getHitData(this_scan_index[i], "nRaysHit");
+            I_miss = I_miss + getHitData(this_scan_index[i], "intensity");
+            E_miss ++;
+          } // or this hitpoint / beam did not intersect the voxel and should not be added to the total number of beams for this voxel
+          
+        } // end of loop through each hit in the current beam
+        
+        // calculate the average dr across all hitpoints for the beam (they should all be the same anyway... but just in case)
+        float drrx = drr / float(beam_array.at(k).size());
+        
+        // if the path length is greater than 0 (it passes throught the current voxel), save it as an element of
+        if( drrx > 0.f )
         {
-            dr_bar_tmp += dr_array.at(c).at(j);
-            sum_term += exp(-1.0*LAD_ref*G_ref*dr_array.at(c).at(j));
+          dr_array.at(c).push_back(drrx);
         }
-        sum_term /= float(dr_array.at(c).size());
-        dr_bar_tmp /= float(dr_array.at(c).size());
         
-        dr_bar_ref[c] = dr_bar_tmp;
-        P_ref[c] = sum_term;
-    }
-    
-    for(uint c=0; c<Ncells; c++)
-    {
-        float dr_var = 0;
-        for(uint j=0; j<dr_array.at(c).size(); j++)
-        {
-            dr_var += pow(dr_array.at(c).at(j) - dr_bar_ref[c], 2.0);
+        if( beamoutput ){
+          // output info about the current beam to file
+          file_beam << s << "," << c << "," << k << "," << R_before << "," << R_inside << "," << R_after << "," << R_miss << "," << E_before << "," << E_inside << "," << E_after << "," << E_miss << "," << sin_theta << "," << drrx << "," << last_drr << "," << I_before << "," << I_inside << "," << I_after << "," << I_miss << std::endl;
         }
-        dr_var /= float(dr_array.at(c).size());
-        dr_var_ref[c] = dr_var;
-    }
-    
-    if( printmessages ){
-        std::cout << "finished P_ref and dr calculations" << std::endl;
-    }
-    
-    //------------------ Perform inversions to get LAD using the different methods for P --------------------//
-    
-    if( printmessages ){
-        std::cout << "Inverting to find LAD..." << std::flush;
-    }
-    
-    // perform LAD inversion using reference Gtheta
-    std::vector<float> LAD_refcheck_Gref = LAD_inversion(P_ref, Gtheta_ref, dr_array, fillAnalytic);
-    std::vector<float> LAD_first_Gref = LAD_inversion(P_first, Gtheta_ref, dr_array, fillAnalytic);
-    std::vector<float> LAD_sequal_Gref = LAD_inversion(P_sequal, Gtheta_ref, dr_array, fillAnalytic);
-    std::vector<float> LAD_equal_Gref = LAD_inversion(P_equal, Gtheta_ref, dr_array, fillAnalytic);
-    std::vector<float> LAD_intensity_Gref = LAD_inversion(P_intensity, Gtheta_ref, dr_array, fillAnalytic);
-    std::vector<float> LAD_exact_Gref = LAD_inversion(P_exact, Gtheta_ref, dr_array, fillAnalytic );
-    
-    // perform LAD inversion using triangulation-estimated Gtheta
-    std::vector<float> LAD_refcheck = LAD_inversion(P_ref, Gtheta, dr_array, fillAnalytic);
-    std::vector<float> LAD_first = LAD_inversion(P_first, Gtheta, dr_array, fillAnalytic);
-    std::vector<float> LAD_sequal = LAD_inversion(P_sequal, Gtheta, dr_array, fillAnalytic);
-    std::vector<float> LAD_equal = LAD_inversion(P_equal, Gtheta, dr_array, fillAnalytic);
-    std::vector<float> LAD_intensity = LAD_inversion(P_intensity, Gtheta, dr_array, fillAnalytic);
-    std::vector<float> LAD_exact = LAD_inversion(P_exact, Gtheta, dr_array, fillAnalytic);
-    
-    if( printmessages ){
-        std::cout << "finished LAD inversions" << std::endl;
-    }
-    
-    // output the voxel level variables
-    std::ofstream file_output;
-    file_output.open("../voxeloutput/voxeloutput.txt");
-    file_output << "cell, grid_center_x, grid_center_y, grid_center_z, grid_size_x, grid_size_y, grid_size_z, Nbeams, LAD_ref, G_ref, dr_bar, dr_var, P_ref, G, P_first, P_sequal, P_equal, P_intensity, P_exact, LADGref_refcheck, LADGref_first, LADGref_sequal, LADGref_equal, LADGref_intensity, LADGref_exact, LAD_refcheck, LAD_first, LAD_sequal, LAD_equal, LAD_intensity, LAD_exact"  << std::endl;
-    
-    for(uint c=0; c<Ncells; c++)
-    {
-        helios::vec3 grid_size = getCellSize(c);
-        helios::vec3 grid_center = getCellCenter(c);
         
-        file_output << c << "," << grid_center.x << "," << grid_center.y << "," << grid_center.z << "," << grid_size.x << "," << grid_size.y << "," << grid_size.z << "," << voxel_beam_count_tot.at(c) << "," << LA_ref[c]/(grid_size.x*grid_size.y*grid_size.z) << "," << Gtheta_ref[c] << "," << dr_bar_ref[c] << "," << dr_var_ref[c] << "," << P_ref[c] << "," << Gtheta[c] << "," << P_first[c] << "," << P_sequal[c] << "," << P_equal[c] << "," << P_intensity[c] << "," << P_exact[c] << "," << LAD_refcheck_Gref[c] << "," << LAD_first_Gref[c] << "," << LAD_sequal_Gref[c] << "," << LAD_equal_Gref[c] << "," << LAD_intensity_Gref[c] << "," << LAD_exact_Gref[c] << "," << LAD_refcheck[c] << "," << LAD_first[c] << "," << LAD_sequal[c] << "," << LAD_equal[c] << "," << LAD_intensity[c] << "," << LAD_exact[c] << std::endl;
-    }
-    file_output.close();
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // calculate terms for different P methods
+        
+        // P_exact
+        if(R_inside != 0 || R_after != 0 || R_miss != 0){ // only count this beam for P_exact if some energy made it to the voxel
+          P_exact_numerator += ((R_after + R_miss) / (R_before + R_inside + R_after + R_miss))*sin_theta;
+          P_exact_denominator += ((R_inside + R_after + R_miss) / (R_before + R_inside + R_after + R_miss))*sin_theta;
+          voxel_beam_count++;
+        }
+        
+        // P_ideal
+        if(R_inside != 0 || R_after != 0){ // only count this beam for P_ideal if some energy hit inside or after the voxel (not including misses)
+          P_ideal_numerator += (R_after / (R_before + R_inside + R_after))*sin_theta;
+          P_ideal_denominator += ((R_inside + R_after) / (R_before + R_inside + R_after))*sin_theta;
+        }else if(R_inside == 0 && R_after == 0 && R_before == 0 && R_miss != 0){ // also count this beam if all the energy missed (but still went through the voxel)
+          P_ideal_numerator += 1*sin_theta;
+          P_ideal_denominator += 1*sin_theta;
+        }
+        
+        // P_intensity
+        if(I_inside != 0 || I_after != 0){ // only count this beam for P_intensity if some energy hit inside or after the voxel (not including misses)
+          P_intensity_numerator += (I_after / (I_before + I_inside + I_after))*sin_theta;
+          P_intensity_denominator += ((I_inside + I_after) / (I_before + I_inside + I_after))*sin_theta;
+        }else if(I_inside == 0 && I_after == 0 && I_before == 0 && I_miss != 0){ // also count this beam if all the energy missed (but still went through the voxel)
+          P_intensity_numerator += 1*sin_theta;
+          P_intensity_denominator += 1*sin_theta;
+        }
+        
+        // P_equal
+        if(E_inside != 0 || E_after != 0){ // only count for P_equal if some hit points were inside or after the voxel
+          P_equal_numerator += (E_after / (E_before + E_inside + E_after))*sin_theta;
+          P_equal_denominator += ((E_inside + E_after) / (E_before + E_inside + E_after))*sin_theta;
+        }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
+          P_equal_numerator += 1*sin_theta;
+          P_equal_denominator += 1*sin_theta;
+        }
+        
+        // P_sequal
+        if(E_inside != 0 || E_after != 0){ // only count for P_sequal if some hit points were inside or after the voxel
+          P_sequal_numerator += E_after / (E_inside + E_after);
+          P_sequal_denominator += 1;
+        }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
+          P_sequal_numerator += 1;
+          P_sequal_denominator += 1;
+        }
+        
+        // P_first
+        if(E_before == 0 && (E_inside != 0 || E_after != 0)){ // only count for P_sequal if some hit points were inside or after the voxel
+          P_first_numerator += W*sin_theta;
+          P_first_denominator += 1*sin_theta;
+        }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
+          P_first_numerator += 1*sin_theta;
+          P_first_denominator += 1*sin_theta;
+        }
+        
+        
+      }// end of loop through all beams for the current cell
+      
+      // save results for the current cell to the arrays
+      
+      P_first_numerator_array.at(c).push_back(P_first_numerator);
+      P_first_denominator_array.at(c).push_back(P_first_denominator);
+      
+      P_sequal_numerator_array.at(c).push_back(P_sequal_numerator);
+      P_sequal_denominator_array.at(c).push_back(P_sequal_denominator);
+      
+      P_equal_numerator_array.at(c).push_back(P_equal_numerator);
+      P_equal_denominator_array.at(c).push_back(P_equal_denominator);
+      
+      P_intensity_numerator_array.at(c).push_back(P_intensity_numerator);
+      P_intensity_denominator_array.at(c).push_back(P_intensity_denominator);
+      
+      P_ideal_numerator_array.at(c).push_back(P_ideal_numerator);
+      P_ideal_denominator_array.at(c).push_back(P_ideal_denominator);
+      
+      P_exact_numerator_array.at(c).push_back(P_exact_numerator);
+      P_exact_denominator_array.at(c).push_back(P_exact_denominator);
+      
+      voxel_beam_count_array.at(c).push_back(voxel_beam_count);
+      
+      hit_before_agg.at(c) += *hit_before;
+      hit_after_agg.at(c) += *hit_after;
+      
+      for( size_t i=0; i<Nhits; i++ ){
+        if( dr[i]>0.f ){
+          dr_agg.at(c).push_back(dr[i]);
+        }
+      }
+      
+      file_beam.close();
+    } // end of loop through all cells
     
+    free( scan_xyz );
+    free( scan_weight );
+    free( dr );
+    free( hit_before );
+    free( hit_after );
+    CUDA_CHECK_ERROR( cudaFree(d_scan_xyz) );
+    CUDA_CHECK_ERROR( cudaFree(d_scan_weight) );
+    CUDA_CHECK_ERROR( cudaFree(d_dr) );
+    CUDA_CHECK_ERROR( cudaFree(d_hit_before) );
+    CUDA_CHECK_ERROR( cudaFree(d_hit_after) );
+    
+  }//end scan loop
+  
+  std::vector<float> P_first(Ncells);
+  std::vector<float> P_sequal(Ncells);
+  std::vector<float> P_equal(Ncells);
+  std::vector<float> P_intensity(Ncells);
+  std::vector<float> P_ideal(Ncells);
+  std::vector<float> P_exact(Ncells);
+  std::vector<uint> voxel_beam_count_tot(Ncells);
+  std::vector<float> dr_bar(Ncells);
+  
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // now aggregate over all scans
+  for( uint c=0; c<Ncells; c++ ){
+    
+    float P_first_numerator_array_agg = 0;
+    float P_first_denominator_array_agg = 0;
+    
+    float P_sequal_numerator_array_agg = 0;
+    float P_sequal_denominator_array_agg = 0;
+    
+    float P_equal_numerator_array_agg = 0;
+    float P_equal_denominator_array_agg = 0;
+    
+    float P_intensity_numerator_array_agg= 0;
+    float P_intensity_denominator_array_agg= 0;
+    
+    float P_ideal_numerator_array_agg= 0;
+    float P_ideal_denominator_array_agg= 0;
+    
+    float P_exact_numerator_array_agg= 0;
+    float P_exact_denominator_array_agg= 0;
+    
+    uint voxel_beam_count_array_agg=0;
+    
+    
+    for( uint s=0; s<Nscans; s++ ){
+      
+      P_first_numerator_array_agg += P_first_numerator_array.at(c).at(s);
+      P_first_denominator_array_agg += P_first_denominator_array.at(c).at(s);
+      
+      P_sequal_numerator_array_agg += P_sequal_numerator_array.at(c).at(s);
+      P_sequal_denominator_array_agg += P_sequal_denominator_array.at(c).at(s);
+      
+      P_equal_numerator_array_agg += P_equal_numerator_array.at(c).at(s);
+      P_equal_denominator_array_agg += P_equal_denominator_array.at(c).at(s);
+      
+      P_intensity_numerator_array_agg += P_intensity_numerator_array.at(c).at(s);
+      P_intensity_denominator_array_agg += P_intensity_denominator_array.at(c).at(s);
+      
+      P_ideal_numerator_array_agg += P_ideal_numerator_array.at(c).at(s);
+      P_ideal_denominator_array_agg += P_ideal_denominator_array.at(c).at(s);
+      
+      P_exact_numerator_array_agg += P_exact_numerator_array.at(c).at(s);
+      P_exact_denominator_array_agg += P_exact_denominator_array.at(c).at(s);
+      voxel_beam_count_array_agg += voxel_beam_count_array.at(c).at(s);
+    }
+    
+    
+    P_first[c] = P_first_numerator_array_agg / P_first_denominator_array_agg ;
+    P_sequal[c] = P_sequal_numerator_array_agg / P_sequal_denominator_array_agg ;
+    P_equal[c] = P_equal_numerator_array_agg / P_equal_denominator_array_agg ;
+    P_intensity[c] = P_intensity_numerator_array_agg / P_intensity_denominator_array_agg ;
+    P_ideal[c] = P_ideal_numerator_array_agg / P_ideal_denominator_array_agg ;
+    P_exact[c] = P_exact_numerator_array_agg / P_exact_denominator_array_agg ;
+    voxel_beam_count_tot[c] = voxel_beam_count_array_agg;
     if( printmessages ){
-        std::cout << "done." << std::endl;
+      std::cout << "Cell " << c << ", voxel_beam_count = " << voxel_beam_count_tot[c]  << std::endl;
+      std::cout << "Cell " << c << ", P_first = " << P_first[c] << std::endl;
+      std::cout << "Cell " << c << ", P_sequal = " << P_sequal[c] << std::endl;
+      std::cout << "Cell " << c << ", P_equal = " << P_equal[c] << std::endl;
+      std::cout << "Cell " << c << ", P_intensity = " << P_intensity[c] << std::endl;
+      std::cout << "Cell " << c << ", P_ideal = " << P_ideal[c] << std::endl;
+      std::cout << "Cell " << c << ", P_exact = " << P_exact[c] << std::endl;
     }
     
+    float mean_dr = 0;
+    for(int j = 0; j < dr_array.at(c).size(); j++)
+    {
+      mean_dr += dr_array.at(c).at(j);
+    }
+    dr_bar[c] = mean_dr/ float(dr_array.at(c).size());
+    if( printmessages ){
+      std::cout << "Cell " << c << ", dr_bar = " <<  dr_bar[c] << std::endl;
+    }
+  } //end of loop through cells to aggregate all scans
+  
+  
+  /// old code in original calculateLeafAreaGPU_testing() ... do we need to keep this??
+  //----------- Calculate number of hits in voxels -------------- //
+  
+  //figure out hits for all scans
+  for( size_t r=0; r< getHitCount(); r++ ){
+    if( getHitGridCell(r)>=0 ){
+      helios::vec3 direction = getHitXYZ(r)-getScanOrigin(getHitScanID(r));
+      direction.normalize();
+      hit_inside_agg.at(getHitGridCell(r)) += sin(acos_safe(direction.z));
+    }
+  }
+  
+  //---------------------- Calculate G(theta) from triangulation --------------------------//
+  
+  std::vector<float> Gtheta;
+  Gtheta.resize(Ncells,0.f);
+  
+  const size_t Ntri = getTriangleCount();
+  
+  std::vector<uint> cell_tri_count;
+  cell_tri_count.resize(Ncells,0);
+  
+  std::vector<float> area_sin_sum;
+  area_sin_sum.resize(Ncells,0.f);
+  
+  for( size_t t=0; t<Ntri; t++ ){
+    
+    Triangulation tri = getTriangle(t);
+    
+    int cell = tri.gridcell;
+    
+    if( cell>=0 && cell<Ncells ){ //triangle is inside a grid cell
+      
+      helios::vec3 t0 = tri.vertex0;
+      helios::vec3 t1 = tri.vertex1;
+      helios::vec3 t2 = tri.vertex2;
+      
+      helios::vec3 v0 = t1-t0;
+      helios::vec3 v1 = t2-t0;
+      helios::vec3 v2 = t2-t1;
+      
+      float L0 = v0.magnitude();
+      float L1 = v1.magnitude();
+      float L2 = v2.magnitude();
+      
+      float S = 0.5f*(L0+L1+L2);
+      float area = sqrt( S*(S-L0)*(S-L1)*(S-L2) );
+      
+      helios::vec3 normal = cross( v0, v2 );
+      normal.normalize();
+      
+      helios::vec3 raydir = t0-getScanOrigin( tri.scanID );
+      raydir.normalize();
+      
+      float theta = fabs(acos_safe(raydir.z));
+      
+      if( area==area ){ //in rare cases you can get area=NaN
+        
+        Gtheta.at(cell) += fabs(normal*raydir)*area*fabs(sin(theta));
+        
+        area_sin_sum.at(cell) += area*fabs(sin(theta));
+        cell_tri_count.at(cell) += 1;
+        
+      }
+      
+    }
+  }
+  
+  for( uint c=0; c<Ncells; c++ ){
+    if( cell_tri_count[c]>0 ){
+      //Gtheta[c] *= float(cell_tri_count[c])/(area_sum[c]*sin_sum[c]);
+      //Gtheta[c] *= float(cell_tri_count[c])/(area_sin_sum[c]);
+      Gtheta[c] *= 1.0/(area_sin_sum[c]);
+      
+      Gtheta_bar[c] += Gtheta[c]/float(Nscans);
+    }
+  }
+  
+  
+  //------------------Calculate "Reference" P and also mean and variance of dr --------------------//
+  // this is the value of P calculated using the reference values of LAD and Gtheta (from calculateSyntheticLeafArea, calculateSyntheticGtheta),
+  // and the path length from all beams for a given cell
+  
+  // first get the reference LA and Gtheta using modified functions that save output to arrays
+  std::vector<float> LA_ref = calculateSyntheticLeafArea(context);
+  std::vector<float> Gtheta_ref = calculateSyntheticGtheta(context);
+  
+  std::vector<float> P_ref(Ncells);
+  P_ref.resize(Ncells,0.f);
+  
+  std::vector<float> dr_bar_ref(Ncells);
+  dr_bar_ref.resize(Ncells,0.f);
+  
+  std::vector<float> dr_var_ref(Ncells);
+  dr_var_ref.resize(Ncells,0.f);
+  
+  for(uint c=0; c<Ncells; c++)
+  {
+    helios::vec3 gridsize = getCellSize(c);
+    float LAD_ref = LA_ref.at(c) / (gridsize.x*gridsize.y*gridsize.z);
+    float G_ref = Gtheta_ref.at(c);
+    
+    float dr_bar_tmp = 0;
+    float sum_term = 0;
+    for(uint j=0; j<dr_array.at(c).size(); j++)
+    {
+      dr_bar_tmp += dr_array.at(c).at(j);
+      sum_term += exp(-1.0*LAD_ref*G_ref*dr_array.at(c).at(j));
+    }
+    sum_term /= float(dr_array.at(c).size());
+    dr_bar_tmp /= float(dr_array.at(c).size());
+    
+    dr_bar_ref[c] = dr_bar_tmp;
+    P_ref[c] = sum_term;
+  }
+  
+  for(uint c=0; c<Ncells; c++)
+  {
+    float dr_var = 0;
+    for(uint j=0; j<dr_array.at(c).size(); j++)
+    {
+      dr_var += pow(dr_array.at(c).at(j) - dr_bar_ref[c], 2.0);
+    }
+    dr_var /= float(dr_array.at(c).size());
+    dr_var_ref[c] = dr_var;
+  }
+  
+  if( printmessages ){
+    std::cout << "finished P_ref and dr calculations" << std::endl;
+  }
+  
+  //------------------ Perform inversions to get LAD using the different methods for P --------------------//
+  
+  if( printmessages ){
+    std::cout << "Inverting to find LAD..." << std::flush;
+  }
+  
+  // perform LAD inversion using reference Gtheta
+  std::vector<float> LAD_refcheck_Gref = LAD_inversion(P_ref, Gtheta_ref, dr_array, fillAnalytic);
+  std::vector<float> LAD_first_Gref = LAD_inversion(P_first, Gtheta_ref, dr_array, fillAnalytic);
+  std::vector<float> LAD_sequal_Gref = LAD_inversion(P_sequal, Gtheta_ref, dr_array, fillAnalytic);
+  std::vector<float> LAD_equal_Gref = LAD_inversion(P_equal, Gtheta_ref, dr_array, fillAnalytic);
+  std::vector<float> LAD_intensity_Gref = LAD_inversion(P_intensity, Gtheta_ref, dr_array, fillAnalytic);
+  std::vector<float> LAD_ideal_Gref = LAD_inversion(P_ideal, Gtheta_ref, dr_array, fillAnalytic);
+  std::vector<float> LAD_exact_Gref = LAD_inversion(P_exact, Gtheta_ref, dr_array, fillAnalytic );
+  
+  // perform LAD inversion using triangulation-estimated Gtheta
+  std::vector<float> LAD_refcheck = LAD_inversion(P_ref, Gtheta, dr_array, fillAnalytic);
+  std::vector<float> LAD_first = LAD_inversion(P_first, Gtheta, dr_array, fillAnalytic);
+  std::vector<float> LAD_sequal = LAD_inversion(P_sequal, Gtheta, dr_array, fillAnalytic);
+  std::vector<float> LAD_equal = LAD_inversion(P_equal, Gtheta, dr_array, fillAnalytic);
+  std::vector<float> LAD_intensity = LAD_inversion(P_intensity, Gtheta, dr_array, fillAnalytic);
+  std::vector<float> LAD_ideal = LAD_inversion(P_ideal, Gtheta, dr_array, fillAnalytic);
+  std::vector<float> LAD_exact = LAD_inversion(P_exact, Gtheta, dr_array, fillAnalytic);
+  
+  if( printmessages ){
+    std::cout << "finished LAD inversions" << std::endl;
+  }
+  
+  // output the voxel level variables
+  std::ofstream file_output;
+  file_output.open("../voxeloutput/voxeloutput.txt");
+  file_output << "cell, grid_center_x, grid_center_y, grid_center_z, grid_size_x, grid_size_y, grid_size_z, Nbeams, LAD_ref, G_ref, dr_bar, dr_var, P_ref, G, P_first, P_sequal, P_equal, P_intensity, P_ideal, P_exact, LADGref_refcheck, LADGref_first, LADGref_sequal, LADGref_equal, LADGref_intensity, LADGref_ideal, LADGref_exact, LAD_refcheck, LAD_first, LAD_sequal, LAD_equal, LAD_intensity, LAD_ideal, LAD_exact"  << std::endl;
+  
+  for(uint c=0; c<Ncells; c++)
+  {
+    helios::vec3 grid_size = getCellSize(c);
+    helios::vec3 grid_center = getCellCenter(c);
+    
+    file_output << c << "," << grid_center.x << "," << grid_center.y << "," << grid_center.z << "," << grid_size.x << "," << grid_size.y << "," << grid_size.z << "," << voxel_beam_count_tot.at(c) << "," << LA_ref[c]/(grid_size.x*grid_size.y*grid_size.z) << "," << Gtheta_ref[c] << "," << dr_bar_ref[c] << "," << dr_var_ref[c] << "," << P_ref[c] << "," << Gtheta[c] << "," << P_first[c] << "," << P_sequal[c] << "," << P_equal[c] << ","  << P_intensity[c] << "," << P_ideal[c] << "," << P_exact[c] << "," << LAD_refcheck_Gref[c] << "," << LAD_first_Gref[c] << "," << LAD_sequal_Gref[c] << "," << LAD_equal_Gref[c] << "," << LAD_intensity_Gref[c] << "," << LAD_ideal_Gref[c] << "," << LAD_exact_Gref[c] << "," << LAD_refcheck[c] << "," << LAD_first[c] << "," << LAD_sequal[c] << "," << LAD_equal[c] << "," << LAD_intensity[c] << "," << LAD_ideal[c] << "," << LAD_exact[c] << std::endl;
+  }
+  file_output.close();
+  
+  if( printmessages ){
+    std::cout << "done." << std::endl;
+  }
+  
 }
 
 std::vector<float> LiDARcloud::LAD_inversion(std::vector<float> &P, std::vector<float> &Gtheta,

--- a/plugins/lidar/src/LiDAR.cu
+++ b/plugins/lidar/src/LiDAR.cu
@@ -3962,3 +3962,465 @@ __global__ void LIDAR_CUDA::intersectTriangles( const size_t Npulse, const int r
   d_hit_fnorm[i_global] = nmin;
   
 }
+
+
+
+
+
+void LiDARcloud::calculateLeafAreaGPU_equal_weighting(bool beamoutput, bool fillAnalytic  ){
+  
+  // calculates LAD using the equal weighting method 
+  // writes all voxel level variables to a file
+  // unlike previous calculateLeafAreaGPU versions, this one does not set the cell leaf area variable and does not filter based on minVoxelHits argument 
+  
+  if( printmessages ){
+    std::cout << "Calculating leaf area..." << std::endl;
+  }
+  
+  if( !triangulationcomputed ){
+    std::cerr << "ERROR (calculateLeafAreaGPU): Triangulation must be performed prior to leaf area calculation. See triangulateHitPoints()." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  
+  if( !hitgridcellcomputed ){
+    calculateHitGridCellGPU();
+  }
+  
+  const uint Nscans = getScanCount();
+  const uint Ncells = getGridCellCount();
+  
+  //variable aggregates over all scans where we just keep tacking hits on the end for all scans
+  std::vector<std::vector<float> > dr_agg; //dr is path length through grid cell
+  dr_agg.resize(Ncells);
+  std::vector<float> G_agg; //G is dot product between ray direction and triangle normal that was hit (only relevant for hits)
+  G_agg.resize(Ncells,0);
+  std::vector<float> hit_before_agg; //hit_before corresponds to scan points that hit something before encountering a particular grid cell
+  hit_before_agg.resize(Ncells,0);
+  std::vector<float> hit_after_agg; //hit_after corresponds to scan points that hit something after encountering a particular grid cell (including something inside that cell)
+  hit_after_agg.resize(Ncells,0);
+  std::vector<float> hit_inside_agg; //hit_inside corresponds to scan points that hit something within a particular grid cell.
+  hit_inside_agg.resize(Ncells,0);
+  
+  //average G(theta)
+  std::vector<float> Gtheta_bar;
+  Gtheta_bar.resize(Ncells,0.f);
+  
+  // nested vectors to save P calculation terms
+  // cell, scan, variable, value
+  std::vector<std::vector<float>>  P_equal_numerator_array(Ncells);
+  std::vector<std::vector<float>>  P_equal_denominator_array(Ncells);
+  
+  std::vector<std::vector<uint>>  voxel_beam_count_array(Ncells);
+  std::vector<std::vector<float>>  dr_array(Ncells);
+  
+  
+  // r is the index of all hitpoints (all scans)
+  // it is saved for the current scan in this_scan_index
+  // i is the index of this_scan_index
+  // so when accessing the things using getHitData(), getHitXYZ(), etc, 
+  // for only one of the scans (this_scan), 
+  // need to use getHitData(this_scan_index[i]) not getHitData(i)
+  
+  ////////////// We are going to perform all calculations on a scan-by-scan basis: loop through each scan
+  for( uint s=0; s<Nscans; s++ ){
+    
+    if( printmessages ){
+      std::cout << "------------------------SCAN = " << s << std::endl;
+    }
+    
+    //only work with hitpoints associated with current scan
+    std::vector<helios::vec3> this_scan_xyz;
+    std::vector<uint> this_scan_index;
+    for( size_t r=0; r< getHitCount(); r++ ){
+      if( getHitScanID(r)==s ){
+        this_scan_xyz.push_back( getHitXYZ(r) );
+        this_scan_index.push_back(r);
+      }
+    }
+    // size of the array of all the hits in this scan
+    size_t Nhits = this_scan_xyz.size();
+    
+    if( printmessages ){
+      std::cout << "Number of hitpoints associated with this scan = Nhits = " << Nhits << std::endl;
+    }
+    
+    // count the number of beams (i.e. don't count multiple hits per beam)
+    float previous_time = -1.f;
+    uint Nbeams = 0;
+    for(uint i=0; i < Nhits; i++)
+    {
+      float current_time = getHitData(this_scan_index[i], "timestamp");
+      if(current_time != previous_time){
+        Nbeams ++;
+        previous_time = current_time;
+      }
+    }
+    
+    if( printmessages ){
+      std::cout << "Number of beams associated with this scan = Nbeams = " << Nbeams << std::endl;
+    }
+    
+    // create a vector each element of which represents a unique beam and is another vector of the hit point indices of this_scan_xyz that is associated with this beam
+    float previous_beam = getHitData(this_scan_index[0], "timestamp");
+    uint beam_ID = 0;
+    std::vector<std::vector<uint>> beam_array(Nbeams);
+    for(uint i=0; i < Nhits; i++)
+    {
+      float current_beam = getHitData(this_scan_index[i], "timestamp");
+      
+      if(current_beam == previous_beam)
+      {
+        beam_array.at(beam_ID).push_back(i); //ERK 
+      }else{
+        beam_ID ++;
+        beam_array.at(beam_ID).push_back(i); //ERK
+        previous_beam = current_beam;
+      }
+      
+    }
+    
+    // set up GPU things for current scan
+    const float3 origin = vec3tofloat3(getScanOrigin(s));
+    float3* scan_xyz = (float3*)malloc( Nhits*sizeof(float3) );
+    float* scan_weight = (float*)malloc( Nhits*sizeof(float) );
+    
+    for( size_t i=0; i<Nhits; i++ ){
+      scan_xyz[i] = vec3tofloat3(this_scan_xyz.at(i));
+      scan_weight[i] = 1.f;
+    }
+    
+    float* hit_before = (float*)malloc( sizeof(float));
+    float* hit_after = (float*)malloc( sizeof(float));
+    float* d_hit_before;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_hit_before, sizeof(float)) );
+    float* d_hit_after;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_hit_after, sizeof(float)) );
+    
+    float3* d_scan_xyz;
+    CUDA_CHECK_ERROR( cudaMalloc((float3**)&d_scan_xyz, Nhits*sizeof(float3)) );
+    CUDA_CHECK_ERROR( cudaMemcpy(d_scan_xyz, scan_xyz, Nhits*sizeof(float3), cudaMemcpyHostToDevice) );
+    
+    float* d_scan_weight;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_scan_weight, Nhits*sizeof(float)) );
+    CUDA_CHECK_ERROR( cudaMemcpy(d_scan_weight, scan_weight, Nhits*sizeof(float), cudaMemcpyHostToDevice) );
+    
+    float* dr = (float*)malloc( Nhits*sizeof(float));
+    float* d_dr;
+    CUDA_CHECK_ERROR( cudaMalloc((float**)&d_dr, Nhits*sizeof(float)) );
+    
+    uint* hit_location = (uint*)malloc( Nhits*sizeof(uint));
+    uint* d_hit_location;
+    CUDA_CHECK_ERROR( cudaMalloc((uint**)&d_hit_location, Nhits*sizeof(uint)) );
+    
+    
+    /////////////////////////////////////////////////////////////////////
+    // now loop through each voxel
+    for( uint c=0; c<Ncells; c++ ){
+      
+      if( printmessages ){
+        std::cout << "----CELL = " << c << std::endl;
+      }
+      
+      std::ofstream file_beam;
+      if( beamoutput){
+        // set up header of file that outputs one row for each beam in the current scan that interacts with the current voxel
+        
+        file_beam.open("../beamoutput/beam_data_s_" + std::to_string(s) + "_c_" + std::to_string(c) + ".txt");
+        file_beam << "scan, cell, beam, E_before, E_inside, E_after, E_miss, sin_theta, dr, last_dr"  << std::endl;
+      }
+      
+      //load the attributes of the grid cell
+      float3 center = vec3tofloat3(getCellCenter(c));
+      float3 anchor = vec3tofloat3(getCellGlobalAnchor(c));
+      float3 size = vec3tofloat3(getCellSize(c));
+      float rotation = getCellRotation(c);
+      
+      CUDA_CHECK_ERROR( cudaMemset( d_hit_location, 0, Nhits*sizeof(uint)) );
+      CUDA_CHECK_ERROR( cudaMemset( d_dr, 0, Nhits*sizeof(float)) );
+      CUDA_CHECK_ERROR( cudaMemset( d_hit_before, 0, sizeof(float)) );
+      CUDA_CHECK_ERROR( cudaMemset( d_hit_after, 0, sizeof(float)) );
+      
+      uint3 dimBlock = make_uint3( min(size_t(512),Nhits), 1, 1 );
+      uint3 dimGrid = make_uint3( ceil(float(Nhits)/dimBlock.x), 1, 1  );
+      
+      if( dimBlock.x==0 && dimGrid.x==0 ){
+        continue;
+      }
+      
+      float scanner_range = 5000.0;
+      intersectGridcell_synthetic <<< dimGrid, dimBlock >>>( Nhits, origin, d_scan_xyz, d_scan_weight, center, anchor, size, rotation, d_dr, d_hit_before, d_hit_after, d_hit_location, scanner_range );
+      
+      cudaDeviceSynchronize();
+      CUDA_CHECK_ERROR( cudaPeekAtLastError() ); //if there was an error inside the kernel, it will show up here
+      
+      //copy results back to host
+      CUDA_CHECK_ERROR( cudaMemcpy( hit_before, d_hit_before, sizeof(float), cudaMemcpyDeviceToHost));
+      CUDA_CHECK_ERROR( cudaMemcpy( hit_after, d_hit_after, sizeof(float), cudaMemcpyDeviceToHost));
+      CUDA_CHECK_ERROR( cudaMemcpy( dr, d_dr, Nhits*sizeof(float), cudaMemcpyDeviceToHost));
+      CUDA_CHECK_ERROR( cudaMemcpy( hit_location, d_hit_location, Nhits*sizeof(uint), cudaMemcpyDeviceToHost));
+      
+      float P_equal_numerator = 0;
+      float P_equal_denominator = 0;
+      uint voxel_beam_count = 0;
+      
+      if( printmessages ){
+        std::cout << "Nbeams = " << Nbeams << std::endl;
+      }
+      ////////////////////////// loop through each beam associated with the current scan
+      for(int k = 0; k < Nbeams; k++){
+        
+        float E_before = 0;
+        float E_inside = 0;
+        float E_after = 0;
+        float E_miss = 0;
+        
+        float sin_theta;
+        // float W = 0;
+        float drr = 0;
+        float last_drr = 0;
+        
+        ////////// loop through the hitpoints in the current beam to get number of rays in each location
+        for(int j = 0; j < beam_array.at(k).size(); j++){
+          
+          // pull out the index of the current scan's current beam's current hit (which is used to access the overall hit index r through this_scan_index[i])
+          uint i = beam_array.at(k).at(j);
+          
+          helios::vec3 direction = getHitXYZ(this_scan_index[i])-getScanOrigin(getHitScanID(this_scan_index[i]));
+          direction.normalize();
+          sin_theta = sin(acos_safe(direction.z));
+          
+          last_drr = dr[i];
+          drr += dr[i];
+          
+          if(hit_location[i] == 1){
+            E_before ++;
+          }else if(hit_location[i] == 2){
+            E_inside ++;
+          }else if(hit_location[i] == 3){
+            E_after ++;
+            //   if(getHitData(this_scan_index[i], "target_index") == 0){ // if this is the first hitpoint for this beam,
+            //      W = 1.0;
+            //    }
+          }else if(hit_location[i] == 4){
+            E_miss ++;
+          } // or this hitpoint / beam did not intersect the voxel and should not be added to the total number of beams for this voxel
+          
+        } // end of loop through each hit in the current beam
+        
+        // calculate the average dr across all hitpoints for the beam (they should all be the same anyway... but just in case)
+        float drrx = drr / float(beam_array.at(k).size());
+        
+        // if the path length is greater than 0 (it passes throught the current voxel), save it as an element of
+        if( drrx > 0.f )
+        {
+          dr_array.at(c).push_back(drrx);
+        }
+        
+        if( beamoutput ){
+          // output info about the current beam to file
+          file_beam << s << "," << c << "," << k << "," << E_before << "," << E_inside << "," << E_after << "," << E_miss << "," << sin_theta << "," << drrx << "," << last_drr << std::endl;
+        }
+        
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // calculate terms equal weighting P method
+        
+        // P_equal
+        if(E_inside != 0 || E_after != 0){ // only count for P_equal if some hit points were inside or after the voxel
+          P_equal_numerator += (E_after / (E_before + E_inside + E_after))*sin_theta;
+          P_equal_denominator += ((E_inside + E_after) / (E_before + E_inside + E_after))*sin_theta;
+          voxel_beam_count++;
+        }else if(E_inside == 0 && E_after == 0 && E_before == 0 && E_miss != 0){ // also count this beam if there is only a "hitpoint" that missed (far after the voxel)
+          P_equal_numerator += 1*sin_theta;
+          P_equal_denominator += 1*sin_theta;
+          voxel_beam_count++;
+        }
+        
+        
+      }// end of loop through all beams for the current cell
+      
+      // save results for the current cell to the arrays
+      P_equal_numerator_array.at(c).push_back(P_equal_numerator);
+      P_equal_denominator_array.at(c).push_back(P_equal_denominator);
+      voxel_beam_count_array.at(c).push_back(voxel_beam_count);
+      hit_before_agg.at(c) += *hit_before;
+      hit_after_agg.at(c) += *hit_after;
+      
+      for( size_t i=0; i<Nhits; i++ ){
+        if( dr[i]>0.f ){
+          dr_agg.at(c).push_back(dr[i]);
+        }
+      }
+      
+      file_beam.close();
+    } // end of loop through all cells
+    
+    free( scan_xyz );
+    free( scan_weight );
+    free( dr );
+    free( hit_before );
+    free( hit_after );
+    CUDA_CHECK_ERROR( cudaFree(d_scan_xyz) );
+    CUDA_CHECK_ERROR( cudaFree(d_scan_weight) );
+    CUDA_CHECK_ERROR( cudaFree(d_dr) );
+    CUDA_CHECK_ERROR( cudaFree(d_hit_before) );
+    CUDA_CHECK_ERROR( cudaFree(d_hit_after) );
+    
+  }//end scan loop
+  
+  std::vector<float> P_equal(Ncells);
+  std::vector<uint> voxel_beam_count_tot(Ncells);
+  std::vector<float> dr_bar(Ncells);
+  
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // now aggregate over all scans
+  for( uint c=0; c<Ncells; c++ ){
+    
+    float P_equal_numerator_array_agg = 0;
+    float P_equal_denominator_array_agg = 0;
+    uint voxel_beam_count_array_agg=0;
+    
+    for( uint s=0; s<Nscans; s++ ){
+      
+      P_equal_numerator_array_agg += P_equal_numerator_array.at(c).at(s);
+      P_equal_denominator_array_agg += P_equal_denominator_array.at(c).at(s);
+      voxel_beam_count_array_agg += voxel_beam_count_array.at(c).at(s);
+    }
+    
+    P_equal[c] = P_equal_numerator_array_agg / P_equal_denominator_array_agg ;
+    voxel_beam_count_tot[c] = voxel_beam_count_array_agg;
+    
+    if( printmessages ){
+      std::cout << "Cell " << c << ", voxel_beam_count = " << voxel_beam_count_tot[c]  << std::endl;
+      std::cout << "Cell " << c << ", P_equal = " << P_equal[c] << std::endl;
+    }
+    
+    float mean_dr = 0;
+    for(int j = 0; j < dr_array.at(c).size(); j++)
+    {
+      mean_dr += dr_array.at(c).at(j);
+    }
+    dr_bar[c] = mean_dr/ float(dr_array.at(c).size());
+    if( printmessages ){
+      std::cout << "Cell " << c << ", dr_bar = " <<  dr_bar[c] << std::endl;
+    }
+  } //end of loop through cells to aggregate all scans
+  
+  
+  /// old code in original calculateLeafAreaGPU_testing() ... do we need to keep this??
+  //----------- Calculate number of hits in voxels -------------- //
+  
+  //figure out hits for all scans
+  for( size_t r=0; r< getHitCount(); r++ ){
+    if( getHitGridCell(r)>=0 ){
+      helios::vec3 direction = getHitXYZ(r)-getScanOrigin(getHitScanID(r));
+      direction.normalize();
+      hit_inside_agg.at(getHitGridCell(r)) += sin(acos_safe(direction.z));
+    }
+  }
+  
+  //---------------------- Calculate G(theta) from triangulation --------------------------//
+  
+  std::vector<float> Gtheta;
+  Gtheta.resize(Ncells,0.f);
+  
+  const size_t Ntri = getTriangleCount();
+  
+  std::vector<uint> cell_tri_count;
+  cell_tri_count.resize(Ncells,0);
+  
+  std::vector<float> area_sin_sum;
+  area_sin_sum.resize(Ncells,0.f);
+  
+  for( size_t t=0; t<Ntri; t++ ){
+    
+    Triangulation tri = getTriangle(t);
+    int cell = tri.gridcell;
+    
+    if( cell>=0 && cell<Ncells ){ //triangle is inside a grid cell
+      
+      helios::vec3 t0 = tri.vertex0;
+      helios::vec3 t1 = tri.vertex1;
+      helios::vec3 t2 = tri.vertex2;
+      
+      helios::vec3 v0 = t1-t0;
+      helios::vec3 v1 = t2-t0;
+      helios::vec3 v2 = t2-t1;
+      
+      float L0 = v0.magnitude();
+      float L1 = v1.magnitude();
+      float L2 = v2.magnitude();
+      
+      float S = 0.5f*(L0+L1+L2);
+      float area = sqrt( S*(S-L0)*(S-L1)*(S-L2) );
+      
+      helios::vec3 normal = cross( v0, v2 );
+      normal.normalize();
+      
+      helios::vec3 raydir = t0-getScanOrigin( tri.scanID );
+      raydir.normalize();
+      
+      float theta = fabs(acos_safe(raydir.z));
+      
+      if( area==area ){ //in rare cases you can get area=NaN
+        
+        Gtheta.at(cell) += fabs(normal*raydir)*area*fabs(sin(theta));
+        area_sin_sum.at(cell) += area*fabs(sin(theta));
+        cell_tri_count.at(cell) += 1;
+        
+      }
+      
+    }
+  }
+  
+  for( uint c=0; c<Ncells; c++ ){
+    if( cell_tri_count[c]>0 ){
+      //Gtheta[c] *= float(cell_tri_count[c])/(area_sum[c]*sin_sum[c]);
+      //Gtheta[c] *= float(cell_tri_count[c])/(area_sin_sum[c]);
+      Gtheta[c] *= 1.0/(area_sin_sum[c]);
+      
+      Gtheta_bar[c] += Gtheta[c]/float(Nscans);
+      std::cout << "Cell " << c << " Gtheta_bar = " <<  Gtheta_bar[c] << std::endl;
+    }
+  }
+  
+  
+  //------------------ Perform inversions to get LAD using the different methods for P --------------------//
+  
+  if( printmessages ){
+    std::cout << "Inverting to find LAD..." << std::flush;
+  }
+  
+  // perform LAD inversion using triangulation-estimated Gtheta
+  std::vector<float> LAD_equal = LAD_inversion(P_equal, Gtheta, dr_array, fillAnalytic);
+  
+  if( printmessages ){
+    std::cout << "finished LAD inversions" << std::endl;
+  }
+  
+  // output the voxel level variables
+  std::ofstream file_output;
+  file_output.open("../voxeloutput/voxeloutput.txt");
+  file_output << "cell, grid_center_x, grid_center_y, grid_center_z, grid_size_x, grid_size_y, grid_size_z, Nbeams, dr_bar, G, P_equal, LAD_equal"  << std::endl;
+  
+  for(uint c=0; c<Ncells; c++)
+  {
+    helios::vec3 grid_size = getCellSize(c);
+    helios::vec3 grid_center = getCellCenter(c);
+    
+    setCellLeafArea(LAD_equal[c]*grid_size.x*grid_size.y*grid_size.z,c);
+    
+    setCellGtheta( Gtheta[c], c );
+    
+    file_output << c << "," << grid_center.x << "," << grid_center.y << "," << grid_center.z << "," << grid_size.x << "," << grid_size.y << "," << grid_size.z << "," << voxel_beam_count_tot.at(c) << "," << dr_bar[c] << "," << Gtheta[c] << "," << P_equal[c] << "," << LAD_equal[c] << std::endl;
+  }
+  file_output.close();
+  
+  if( printmessages ){
+    std::cout << "done." << std::endl;
+  }
+  
+}
+
+
+
+


### PR DESCRIPTION
*LiDAR*
- added non-idealized intensity-based weighting to calculateLeafAreaGPU_synthetic
- added calculateLeafAreaGPU_equal_weighting that pulls out only the equal weighting method from the _synthetic version for use with actual LiDAR data
- fixed bug in calculateLeafAreaGPU_synthetic related to indexing when the first beam of a scan was a "miss"
- calculateLeafAreaGPU_synthetic can now print LAD and G in addition to P to console
- gapfillMisses now adds hitpoints directly to the point cloud and adds timestamp and target_index as data
- an overloaded version of gapfillMisses allows for extrapolation of only beams that intersect the axis-aligned bounding box of the voxel grid to save time and reduce unwanted gap filling