### PR TITLE
Minor bugs in SyntheticAnnotation plugin

### DIFF
--- a/plugins/syntheticannotation/CMakeLists.txt
+++ b/plugins/syntheticannotation/CMakeLists.txt
@@ -7,6 +7,11 @@ include_directories( "${BASE_DIRECTORY}/core/include" )
 include_directories( "${BASE_DIRECTORY}/plugins/visualizer/include" )
 include_directories( "${BASE_DIRECTORY}/plugins/visualizer/lib/glm" )
 
+include_directories(include)
+include_directories(../../core/include)
+include_directories(../../plugins/visualizer/include)
+include_directories(../../plugins/visualizer/lib/glm)
+
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
 endif()

--- a/plugins/syntheticannotation/src/SyntheticAnnotation.cpp
+++ b/plugins/syntheticannotation/src/SyntheticAnnotation.cpp
@@ -139,8 +139,8 @@ void SyntheticAnnotation::setWindowSize( const uint __window_width, const uint _
 }
 
 void SyntheticAnnotation::setCameraPosition(const helios::vec3 &__camera_position, const helios::vec3 &__camera_lookat) {
-    std::vector<vec3> position = {camera_position};
-    std::vector<vec3> lookat = {camera_lookat};
+    std::vector<vec3> position = {__camera_position};
+    std::vector<vec3> lookat = {__camera_lookat};
     setCameraPosition( position, lookat );
 }
 


### PR DESCRIPTION
Hi, I found some minor bugs when I was using the SyntheticAnnotation
1. Fixed include_directories in SyntheticAnnotation CMakeLists.txt
It sometimes couldn't find the header files, so I added the relative paths

2. Fixed SyntheticAnnotation::setCameraPosition does not use the input variable
SyntheticAnnotation annotation(&context);
annotation.setCameraPosition does not work because the input variables are not used.