### PR TITLE
Tree orchards and vineyards generation improvements

### DIFF
--- a/plugins/canopygenerator/include/CanopyGenerator.h
+++ b/plugins/canopygenerator/include/CanopyGenerator.h
@@ -270,6 +270,15 @@ struct BaseGrapeVineParameters : BaseCanopyParameters{
   int wood_subdivisions;
   //! Spread value for the number of wood subdivisions. With any new canopy or plant generation, the maximum number of wood subdivisions would be between wood_subdivisions - wood_subdivisions_spread and wood_subdivisions + wood_subdivisions_spread.
   int wood_subdivisions_spread;
+
+  //! Probability for a plant to be dead, i.e. without any leaves or grapes
+  float dead_probability;
+
+  //! Probability for a plant to be missing
+  /**
+   * \note Only applicable when building a canopy. If you are building an individual plant, well... just don't build it.
+   */
+  float missing_plant_probability;
   
   //! Spacing between adjacent plants along the row direction.
   float plant_spacing;

--- a/plugins/canopygenerator/include/CanopyGenerator.h
+++ b/plugins/canopygenerator/include/CanopyGenerator.h
@@ -254,6 +254,8 @@ struct BaseGrapeVineParameters : BaseCanopyParameters{
 
   //! Maximum width of leaves. Leaf width increases logarithmically from the shoot tip, so leaf_width is the width at the base of the shoot.
   float leaf_width;
+  //! Spread value for the maximum leaf width. With any new canopy or plant generation, the maximum leaf width would be between leaf_width - leaf_width_spread and leaf_width + leaf_width_spread.
+  float leaf_width_spread;
 
   //! Number of sub-division segments per leaf
   helios::int2 leaf_subdivisions;
@@ -266,57 +268,90 @@ struct BaseGrapeVineParameters : BaseCanopyParameters{
 
   //! Number of radial subdivisions for trunk/cordon/shoot tubes
   int wood_subdivisions;
+  //! Spread value for the number of wood subdivisions. With any new canopy or plant generation, the maximum number of wood subdivisions would be between wood_subdivisions - wood_subdivisions_spread and wood_subdivisions + wood_subdivisions_spread.
+  int wood_subdivisions_spread;
   
   //! Spacing between adjacent plants along the row direction.
   float plant_spacing;
+  //! Spread value for the plant spacing. The spacing between adjacent plants along a row would vary between plant_spacing - plant_spacing_spread and plant_spacing + plant_spacing_spread.
+  float plant_spacing_spread;
 
   //! Spacing between plant rows.
   float row_spacing;
+  //! Spread value for the row spacing. This allows to vary the alignment of plants along a row. The spacing between two plants of adjacent rows would be between row_spacing - row_spacing_spread and row_spacing + row_spacing_spread.
+  float row_spacing_spread;
 
   //! Distance between the ground and top of trunks
   float trunk_height;
+  //! Spread value for the trunk height. With any new canopy or plant generation, the trunk height would be between trunk_height - trunk_height_spread and trunk_height + trunk_height_spread.
+  float trunk_height_spread;
 
   //! Radius of the trunk at the widest point
   float trunk_radius;
+  //! Spread value for the trunk radius. With any new canopy or plant generation, the trunk radius would be between trunk_radius - trunk_radius_spread and trunk_radius + trunk_radius_spread.
+  float trunk_radius_spread;
 
   //! Distance between the ground and cordon. Note - must be greater than or equal to the trunk height.
   float cordon_height;
+  //! Spread value for the cordon height. With any new canopy or plant generation, the cordon height would be between cordon_height - cordon_height_spread and cordon_height + cordon_height_spread.
+  float cordon_height_spread;
 
   //! Radius of cordon branches.
   float cordon_radius;
+  //! Spread value for the cordon radius. With any new canopy or plant generation, the cordon radius would be between cordon_radius - cordon_radius_spread and cordon_radius + cordon_radius_spread.
+  float cordon_radius_spread;
 
   //! Length of shoots.
   float shoot_length;
+  //! Spread value for the shoot length. With any new canopy or plant generation, the shoot length would be between shoot_length - shoot_length_spread and shoot_length + shoot_length_spread.
+  float shoot_length_spread;
 
   //! Radius of shoot branches.
   float shoot_radius;
+  //! Spread value for the shoot radius. With any new canopy or plant generation, the shoot radius would be between shoot_radius - shoot_radius_spread and shoot_radius + shoot_radius_spread.
+  float shoot_radius_spread;
 
   //! Number of shoots on each cordon.
   uint shoots_per_cordon;
+  //! Spread value for the number of shoots per cordon. With any new canopy or plant generation, the number of shoots per cordon would be between shoots_per_cordon - shoots_per_cordon_spread and shoots_per_cordon + shoots_per_cordon_spread.
+  uint shoots_per_cordon_spread;
 
   //! Spacing between adjacent leaves as a fraction of the local leaf width. E.g., leaf_spacing_fraction = 1 would give a leaf spacing equal to the leaf width.
   float leaf_spacing_fraction;
+  //! Spread value for the leaf spacing fraction. With any new canopy or plant generation, the leaf spacing fraction would be between leaf_spacing_fraction - leaf_spacing_fraction_spread and leaf_spacing_fraction + leaf_spacing_fraction_spread.
+  float leaf_spacing_fraction_spread;
 
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
 
   //! Radius of grape berries
   float grape_radius;
+  //! Spread value for the grape radius. With any new canopy or plant generation, the grape radius would be between grape_radius - grape_radius_spread and grape_radius + grape_radius_spread.
+  float grape_radius_spread;
 
   //! Maximum horizontal radius of grape clusters
   float cluster_radius;
+  //! Spread value for the cluster radius. With any new canopy or plant generation, the cluster radius would be between cluster_radius - cluster_radius_spread and cluster_radius + cluster_radius_spread.
+  float cluster_radius_spread;
 
   //! Maximum height of grape clusters along the shoot as a fraction of the total shoot length
   float cluster_height_max;
+  //! Spread value for the cluster height. With any new canopy or plant generation, the cluster height would be between cluster_height - cluster_height_spread and cluster_height + cluster_height_spread.
+  float cluster_height_max_spread;
 
   //! Color of grapes
   helios::RGBcolor grape_color;
 
   //! Number of azimuthal and zenithal subdivisions making up berries (will result in roughly 2*(grape_subdivisions)^2 triangles per grape berry)
   uint grape_subdivisions;
+  //! Spread value for the number of grape subdivisions. With any new canopy or plant generation, the number of grape subdivisions would be between grape_subdivisions - grape_subdivisions_spread and grape_subdivisions + grape_subdivisions_spread.
+  uint grape_subdivisions_spread;
 
   //! 
   std::vector<float> leaf_angle_PDF;
+
+  //! Spread value for the canopy rotation. With any new canopy or plant generation, the canopy/plant rotation would be between canopy_rotation - canopy_rotation_spread and canopy_rotation + canopy_rotation_spread.
+  float canopy_rotation_spread;
 
 };
 
@@ -370,12 +405,18 @@ struct SplitGrapevineParameters : BaseGrapeVineParameters{
 
   //! Spacing between two opposite cordons
   float cordon_spacing;
+  //! Spread value for the cordon spacing. With any new canopy or plant generation, the cordon spacing would be between cordon_spacing - cordon_spacing_spread and cordon_spacing + cordon_spacing_spread.
+  float cordon_spacing_spread;
 
   //! Average angle of the shoot at the base (shoot_angle_base=0 points shoots upward; shoot_angle_base=M_PI points shoots downward and makes a Geneva Double Curtain)
   float shoot_angle_base;
+  //! Spread value for the base shoot angle. With any new canopy or plant generation, the base shoot angle would be between shoot_angle_base - shoot_angle_base_spread and shoot_angle_base + shoot_angle_base_spread.
+  float shoot_angle_base_spread;
   
   //! Average angle of the shoot at the tip (shoot_angle=0 is a completely vertical shoot; shoot_angle=M_PI is a downward-pointing shoot)
   float shoot_angle_tip;
+  //! Spread value for the base shoot angle. With any new canopy or plant generation, the base shoot angle would be between shoot_angle_tip - shoot_angle_tip_spread and shoot_angle_tip + shoot_angle_tip_spread.
+  float shoot_angle_tip_spread;
   
 };
 

--- a/plugins/canopygenerator/include/CanopyGenerator.h
+++ b/plugins/canopygenerator/include/CanopyGenerator.h
@@ -19,11 +19,63 @@
 #include "Context.h"
 #include <random>
 
+class CanopyGenerator;
+
+//! Base struct class for Canopy parameters
+struct BaseCanopyParameters{
+
+  //! Default constructor
+  BaseCanopyParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  BaseCanopyParameters(const pugi::xml_node canopy_node);
+
+  virtual ~BaseCanopyParameters() = default;
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  virtual void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) = 0;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  virtual void buildCanopy(CanopyGenerator& canopy_generator) = 0;
+
+  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
+  helios::vec3 canopy_origin;
+
+  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
+  float canopy_rotation;
+
+};
+
 //! Parameters defining the homogeneous canopy
-struct HomogeneousCanopyParameters{
+struct HomogeneousCanopyParameters : BaseCanopyParameters{
 
   //! Default constructor
   HomogeneousCanopyParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  HomogeneousCanopyParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Length of leaf in x- and y- directions (prior to rotation)
   helios::vec2 leaf_size;
@@ -49,9 +101,6 @@ struct HomogeneousCanopyParameters{
   //! Horizontal extent of the canopy in the x- and y-directions.
   helios::vec2 canopy_extent;
 
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
   //! 
   std::vector<float> leaf_angle_PDF;
 
@@ -61,10 +110,27 @@ struct HomogeneousCanopyParameters{
 };
 
 //! Parameters defining the canopy with spherical crowns
-struct SphericalCrownsCanopyParameters{
+struct SphericalCrownsCanopyParameters : BaseCanopyParameters{
 
   //! Default constructor
   SphericalCrownsCanopyParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  SphericalCrownsCanopyParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Length of leaf in x- and y- directions (prior to rotation)
   helios::vec2 leaf_size;
@@ -96,22 +162,33 @@ struct SphericalCrownsCanopyParameters{
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
 
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
   //! 
   std::vector<float> leaf_angle_PDF;
   
 };
 
 //! Parameters defining the canopy with conical crowns
-struct ConicalCrownsCanopyParameters{
+struct ConicalCrownsCanopyParameters : BaseCanopyParameters{
 
     //! Default constructor
     ConicalCrownsCanopyParameters();
+
+    /**
+     * \param[in] canopy_node XML node containing the canopy parameters
+     */
+    ConicalCrownsCanopyParameters(const pugi::xml_node canopy_node);
+
+    //! Sets canopy parameters from the given XML node
+    /**
+     * \param[in] canopy_node XML node containing the canopy parameters
+     */
+    void readParametersFromXML(const pugi::xml_node canopy_node);
+
+    //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+    void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+    //! Makes the given Canopy generator build a canopy of our type with our parameters
+    void buildCanopy(CanopyGenerator& canopy_generator) override;
 
     //! Length of leaf in x- and y- directions (prior to rotation)
     helios::vec2 leaf_size;
@@ -146,22 +223,34 @@ struct ConicalCrownsCanopyParameters{
     //! Number of crowns/plants in the x- and y-directions.
     helios::int2 plant_count;
 
-    //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-    helios::vec3 canopy_origin;
-
-    //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-    float canopy_rotation;
-
     //!
     std::vector<float> leaf_angle_PDF;
 
 };
 
-//! Parameters defining the grapevine canopy with vertical shoot positioned (VSP) trellis
-struct VSPGrapevineParameters{
+struct BaseGrapeVineParameters : BaseCanopyParameters{
 
   //! Default constructor
-  VSPGrapevineParameters();
+  BaseGrapeVineParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  BaseGrapeVineParameters(const pugi::xml_node canopy_node);
+
+  virtual ~BaseGrapeVineParameters() = default;
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Maximum width of leaves. Leaf width increases logarithmically from the shoot tip, so leaf_width is the width at the base of the shoot.
   float leaf_width;
@@ -195,7 +284,7 @@ struct VSPGrapevineParameters{
 
   //! Radius of cordon branches.
   float cordon_radius;
-  
+
   //! Length of shoots.
   float shoot_length;
 
@@ -210,12 +299,6 @@ struct VSPGrapevineParameters{
 
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
-
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
 
   //! Radius of grape berries
   float grape_radius;
@@ -234,264 +317,141 @@ struct VSPGrapevineParameters{
 
   //! 
   std::vector<float> leaf_angle_PDF;
+
+};
+
+//! Parameters defining the grapevine canopy with vertical shoot positioned (VSP) trellis
+struct VSPGrapevineParameters : BaseGrapeVineParameters{
+
+  //! Default constructor
+  VSPGrapevineParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  VSPGrapevineParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
   
 };
 
 //! Parameters defining the grapevine canopy with a split (quad) trellis
-struct SplitGrapevineParameters{
+struct SplitGrapevineParameters : BaseGrapeVineParameters{
 
   //! Default constructor
   SplitGrapevineParameters();
 
-  //! Maximum width of leaves. Leaf width increases logarithmically from the shoot tip, so leaf_width is the width at the base of the shoot.
-  float leaf_width;
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  SplitGrapevineParameters(const pugi::xml_node canopy_node);
 
-  //! Number of sub-division segments per leaf
-  helios::int2 leaf_subdivisions;
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
 
-  //! Path to texture map file for leaves.
-  std::string leaf_texture_file;
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
 
-  //! Path to texture map file for trunks/branches.
-  std::string wood_texture_file;
-
-  //! Number of radial subdivisions for trunk/cordon/shoot tubes
-  int wood_subdivisions;
-  
-  //! Spacing between adjacent plants along the row direction.
-  float plant_spacing;
-
-  //! Spacing between plant rows.
-  float row_spacing;
-
-  //! Distance between the ground and top of trunks
-  float trunk_height;
-
-  //! Radius of the trunk at the widest point
-  float trunk_radius;
-
-  //! Distance between the ground and cordon. Note - must be greater than or equal to the trunk height.
-  float cordon_height;
-
-  //! Radius of cordon branches.
-  float cordon_radius;
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Spacing between two opposite cordons
   float cordon_spacing;
-  
-  //! Length of shoots.
-  float shoot_length;
-
-  //! Radius of shoot branches.
-  float shoot_radius;
-
-  //! Number of shoots on each cordon.
-  uint shoots_per_cordon;
 
   //! Average angle of the shoot at the base (shoot_angle_base=0 points shoots upward; shoot_angle_base=M_PI points shoots downward and makes a Geneva Double Curtain)
   float shoot_angle_base;
   
   //! Average angle of the shoot at the tip (shoot_angle=0 is a completely vertical shoot; shoot_angle=M_PI is a downward-pointing shoot)
   float shoot_angle_tip;
-
-  //! Spacing between adjacent leaves as a fraction of the local leaf width. E.g., leaf_spacing_fraction = 1 would give a leaf spacing equal to the leaf width.
-  float leaf_spacing_fraction;
-
-  //! Number of crowns/plants in the x- and y-directions.
-  helios::int2 plant_count;
-
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
-  //! Radius of grape berries
-  float grape_radius;
-
-  //! Maximum horizontal radius of grape clusters
-  float cluster_radius;
-
-  //! Maximum height of grape clusters along the shoot as a fraction of the total shoot length
-  float cluster_height_max;
-
-  //! Color of grapes
-  helios::RGBcolor grape_color;
-
-  //! Number of azimuthal and zenithal subdivisions making up berries (will result in roughly grape_subdivisions^2 triangles per grape berry)
-  uint grape_subdivisions;
-  
-  //! 
-  std::vector<float> leaf_angle_PDF;
   
 };
 
 //! Parameters defining the grapevine canopy with unilateral trellis
-struct UnilateralGrapevineParameters{
+struct UnilateralGrapevineParameters : BaseGrapeVineParameters{
 
   //! Default constructor
   UnilateralGrapevineParameters();
 
-  //! Maximum width of leaves. Leaf width increases logarithmically from the shoot tip, so leaf_width is the width at the base of the shoot.
-  float leaf_width;
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  UnilateralGrapevineParameters(const pugi::xml_node canopy_node);
 
-  //! Number of sub-division segments per leaf
-  helios::int2 leaf_subdivisions;
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
 
-  //! Path to texture map file for leaves.
-  std::string leaf_texture_file;
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
 
-  //! Path to texture map file for trunks/branches.
-  std::string wood_texture_file;
-
-  //! Number of radial subdivisions for trunk/cordon/shoot tubes
-  int wood_subdivisions;
-  
-  //! Spacing between adjacent plants along the row direction.
-  float plant_spacing;
-
-  //! Spacing between plant rows.
-  float row_spacing;
-
-  //! Distance between the ground and top of trunks
-  float trunk_height;
-
-  //! Radius of the trunk at the widest point
-  float trunk_radius;
-
-  //! Distance between the ground and cordon. Note - must be greater than or equal to the trunk height.
-  float cordon_height;
-
-  //! Radius of cordon branches.
-  float cordon_radius;
-  
-  //! Length of shoots.
-  float shoot_length;
-
-  //! Radius of shoot branches.
-  float shoot_radius;
-
-  //! Number of shoots on each cordon.
-  uint shoots_per_cordon;
-
-  //! Spacing between adjacent leaves as a fraction of the local leaf width. E.g., leaf_spacing_fraction = 1 would give a leaf spacing equal to the leaf width.
-  float leaf_spacing_fraction;
-
-  //! Number of crowns/plants in the x- and y-directions.
-  helios::int2 plant_count;
-
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
-  //! Radius of grape berries
-  float grape_radius;
-
-  //! Maximum horizontal radius of grape clusters
-  float cluster_radius;
-
-  //! Maximum height of grape clusters along the shoot as a fraction of the total shoot length
-  float cluster_height_max;
-
-  //! Color of grapes
-  helios::RGBcolor grape_color;
-
-  //! Number of azimuthal and zenithal subdivisions making up berries (will result in roughly grape_subdivisions^2 triangles per grape berry)
-  uint grape_subdivisions;
-
-  //! 
-  std::vector<float> leaf_angle_PDF;
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
   
 };
 
 
 //! Parameters defining the grapevine canopy with goblet (vent a taille) trellis
-struct GobletGrapevineParameters{
+struct GobletGrapevineParameters : BaseGrapeVineParameters{
 
   //! Default constructor
   GobletGrapevineParameters();
 
-  //! Maximum width of leaves. Leaf width increases logarithmically from the shoot tip, so leaf_width is the width at the base of the shoot.
-  float leaf_width;
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  GobletGrapevineParameters(const pugi::xml_node canopy_node);
 
-  //! Number of sub-division segments per leaf
-  helios::int2 leaf_subdivisions;
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
 
-  //! Path to texture map file for leaves.
-  std::string leaf_texture_file;
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
 
-  //! Path to texture map file for trunks/branches.
-  std::string wood_texture_file;
-
-  //! Number of radial subdivisions for trunk/cordon/shoot tubes
-  int wood_subdivisions;
-  
-  //! Spacing between adjacent plants along the row direction.
-  float plant_spacing;
-
-  //! Spacing between plant rows.
-  float row_spacing;
-
-  //! Distance between the ground and top of trunks
-  float trunk_height;
-
-  //! Radius of the trunk at the widest point
-  float trunk_radius;
-
-  //! Distance between the ground and cordon. Note - must be greater than or equal to the trunk height.
-  float cordon_height;
-
-  //! Radius of cordon branches.
-  float cordon_radius;
-  
-  //! Length of shoots.
-  float shoot_length;
-
-  //! Radius of shoot branches.
-  float shoot_radius;
-
-  //! Number of shoots on each cordon.
-  uint shoots_per_cordon;
-
-  //! Spacing between adjacent leaves as a fraction of the local leaf width. E.g., leaf_spacing_fraction = 1 would give a leaf spacing equal to the leaf width.
-  float leaf_spacing_fraction;
-
-  //! Number of crowns/plants in the x- and y-directions.
-  helios::int2 plant_count;
-
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
-  //! Radius of grape berries
-  float grape_radius;
-
-  //! Maximum horizontal radius of grape clusters
-  float cluster_radius;
-
-  //! Maximum height of grape clusters along the shoot as a fraction of the total shoot length
-  float cluster_height_max;
-
-  //! Color of grapes
-  helios::RGBcolor grape_color;
-
-  //! Number of azimuthal and zenithal subdivisions making up berries (will result in roughly grape_subdivisions^2 triangles per grape berry)
-  uint grape_subdivisions;
-
-  //! 
-  std::vector<float> leaf_angle_PDF;
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
   
 };
 
 //! Parameters defining the white spruce
-struct WhiteSpruceCanopyParameters{
+struct WhiteSpruceCanopyParameters : BaseCanopyParameters{
 
   //! Default constructor
   WhiteSpruceCanopyParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  WhiteSpruceCanopyParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Width of needles
   float needle_width;
@@ -543,20 +503,31 @@ struct WhiteSpruceCanopyParameters{
 
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
-
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
   
 };
 
 //! Parameters defining the tomato plant canopy
-struct TomatoParameters{
+struct TomatoParameters : BaseCanopyParameters{
 
   //! Default constructor
   TomatoParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  TomatoParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Maximum width of leaves. 
   float leaf_length;
@@ -585,12 +556,6 @@ struct TomatoParameters{
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
 
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
   //! Radius of tomato fruit
   float fruit_radius;
 
@@ -603,10 +568,27 @@ struct TomatoParameters{
 };
 
 //! Parameters defining the strawberry plant canopy
-struct StrawberryParameters{
+struct StrawberryParameters : BaseCanopyParameters{
 
   //! Default constructor
   StrawberryParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  StrawberryParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Maximum width of leaves. 
   float leaf_length;
@@ -641,12 +623,6 @@ struct StrawberryParameters{
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
 
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
   //! Radius of strawberry fruit
   float fruit_radius;
 
@@ -662,10 +638,27 @@ struct StrawberryParameters{
 };
 
 //! Parameters defining the walnut tree canopy
-struct WalnutCanopyParameters{
+struct WalnutCanopyParameters : BaseCanopyParameters{
 
   //! Default constructor
   WalnutCanopyParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  WalnutCanopyParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Maximum length of leaves along midrib. 
   float leaf_length;
@@ -709,20 +702,31 @@ struct WalnutCanopyParameters{
 
   //! Number of crowns/plants in the x- and y-directions.
   helios::int2 plant_count;
-
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
   
 };
 
 //! Parameters defining Sorghum plant canopy
-struct SorghumCanopyParameters{
+struct SorghumCanopyParameters : BaseCanopyParameters{
 
 //! Default constructor
     SorghumCanopyParameters();
+
+/**
+ * \param[in] canopy_node XML node containing the canopy parameters
+ */
+    SorghumCanopyParameters(const pugi::xml_node canopy_node);
+
+//! Sets canopy parameters from the given XML node
+/**
+ * \param[in] canopy_node XML node containing the canopy parameters
+ */
+    void readParametersFromXML(const pugi::xml_node canopy_node);
+
+//! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+    void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+//! Makes the given Canopy generator build a canopy of our type with our parameters
+    void buildCanopy(CanopyGenerator& canopy_generator) override;
 
 //! Sorghum categorized into 5 stages; 1 - Three leaf stage, 2 - Five leaf stage, 3 - Panicle initiation and flag leaf emergency, 4 - Booting, and flowering, 5 - Maturity;  Input of a value other than 1-5 will output stage 5
     int sorghum_stage;
@@ -918,16 +922,30 @@ struct SorghumCanopyParameters{
 //! Number of crowns/plants in the x- and y-directions.
     helios::int2 plant_count;
 
-//! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0.
-    helios::vec3 canopy_origin;
-
 };
 
 //! Parameters defining the bean plant canopy
-struct BeanParameters{
+struct BeanParameters : BaseCanopyParameters{
 
   //! Default constructor
   BeanParameters();
+
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  BeanParameters(const pugi::xml_node canopy_node);
+
+  //! Sets canopy parameters from the given XML node
+  /**
+   * \param[in] canopy_node XML node containing the canopy parameters
+   */
+  void readParametersFromXML(const pugi::xml_node canopy_node);
+
+  //! Makes the given Canopy generator build a single plant of our canopy type with our parameters at the given position
+  void buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin) override;
+
+  //! Makes the given Canopy generator build a canopy of our type with our parameters
+  void buildCanopy(CanopyGenerator& canopy_generator) override;
 
   //! Maximum width of leaves.
   float leaf_length;
@@ -965,12 +983,6 @@ struct BeanParameters{
   //! Probability that a plant in the canopy germinated
   float germination_probability;
 
-  //! Cartesian (x,y,z) coordinate of the bottom center point of the canopy (i.e., specifying z=0 places the bottom surface of the canopy at z=0).
-  helios::vec3 canopy_origin;
-
-  //! Azimuthal rotation of the canopy about the canopy origin. Note that if canopy_rotation is not equal to zero, the plant_spacing and plant_count parameters are defined in the x- and y-directions before rotation.
-  float canopy_rotation;
-
   //! Length of bean pods
   float pod_length;
 
@@ -994,11 +1006,21 @@ class CanopyGenerator{
   //! Unit testing routine
  int selfTest();
 
-  //! Build canopy geometries based on parameters specified in an XML file
+  //! Stores the given canopy parameters
+  template <typename CanopyType, typename... Args>
+  void storeCanopyParameters(Args&&... args);
+
+  std::vector<std::shared_ptr<BaseCanopyParameters>> getCanopyParametersList();
+
+  //! Reads the XML file of the given name and stores all the configured canopy parameters
   /**
    * \param[in] filename Path to XML file to be read
+   * \param[in] build true if we should build all the canopies for which we read parameters in the XML file
    */
-  void loadXML( const char* filename );
+  void loadXML( const char* filename, bool build = true );
+
+  //! Builds canopies for all the stored canopy parameters
+  void buildCanopies();
 
   //! Build a canopy consisting of a homogeneous volume of leaves
   /**
@@ -1164,6 +1186,15 @@ class CanopyGenerator{
 
   //---------- PLANT GEOMETRIES ------------ //
 
+  //! Builds individual plants based on the stored canopy parameters, at the given position
+  /**
+   * \note If you have multiple canopy parameters stored, this will try to build an individual plant of each type at the same position
+   */
+  void buildIndividualPlants(helios::vec3 position);
+
+  //! Builds individual plants based on the stored canopy parameters (using canopy_origin as the position)
+  void buildIndividualPlants();
+
   //! Function to add an individual grape berry cluster
   /**
    * \param[in] position Cartesian (x,y,z) position of the cluster main stem.
@@ -1263,6 +1294,9 @@ uint grapevineGoblet( const GobletGrapevineParameters &params, const helios::vec
  private:
 
   helios::Context* context;
+
+  //! List of stored canopy parameters, which can then be used to build individual plants or whole canopies
+  std::vector<std::shared_ptr<BaseCanopyParameters>> canopy_parameters_list;
 
   //! UUIDs for trunk primitives
   /**

--- a/plugins/canopygenerator/include/CanopyGenerator.h
+++ b/plugins/canopygenerator/include/CanopyGenerator.h
@@ -300,6 +300,11 @@ struct BaseGrapeVineParameters : BaseCanopyParameters{
   //! Spread value for the trunk radius. With any new canopy or plant generation, the trunk radius would be between trunk_radius - trunk_radius_spread and trunk_radius + trunk_radius_spread.
   float trunk_radius_spread;
 
+  //! Length of the cordons. By default, half the plant spacing.
+  float cordon_length;
+  //! Spread value for the cordon length. With any new canopy or plant generation, the cordon length would be between cordon_length - cordon_length_spread and cordon_length + cordon_length_spread.
+  float cordon_length_spread;
+
   //! Distance between the ground and cordon. Note - must be greater than or equal to the trunk height.
   float cordon_height;
   //! Spread value for the cordon height. With any new canopy or plant generation, the cordon height would be between cordon_height - cordon_height_spread and cordon_height + cordon_height_spread.

--- a/plugins/canopygenerator/src/CanopyGenerator.cpp
+++ b/plugins/canopygenerator/src/CanopyGenerator.cpp
@@ -18,7 +18,37 @@
 
 using namespace helios;
 
-HomogeneousCanopyParameters::HomogeneousCanopyParameters(){
+//! Float null value in XML parameters
+static float nullvalue_f = 99999;
+//! Int null value in XML parameters
+static int nullvalue_i = 99999;
+//! String null value in XML parameters
+static std::string nullvalue_s = "99999";
+
+BaseCanopyParameters::BaseCanopyParameters(){
+    canopy_origin = make_vec3(0,0,0);
+    canopy_rotation = 0;
+}
+
+BaseCanopyParameters::BaseCanopyParameters(const pugi::xml_node canopy_node) : BaseCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void BaseCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    // ----- canopy origin ------ //
+    vec3 new_canopy_origin = XMLloadvec3(canopy_node, "canopy_origin");
+    if (new_canopy_origin.x != nullvalue_f && new_canopy_origin.y != nullvalue_f) {
+        canopy_origin = new_canopy_origin;
+    }
+
+    // ----- canopy rotation ------ //
+    float new_canopy_rotation = XMLloadfloat(canopy_node, "canopy_rotation");
+    if (new_canopy_rotation != nullvalue_f) {
+        canopy_rotation = new_canopy_rotation;
+    }
+}
+
+HomogeneousCanopyParameters::HomogeneousCanopyParameters() : BaseCanopyParameters(){
 
     leaf_size = make_vec2(0.1,0.1);
 
@@ -34,13 +64,75 @@ HomogeneousCanopyParameters::HomogeneousCanopyParameters(){
 
     canopy_extent = make_vec2(5,5);
 
-    canopy_origin = make_vec3(0,0,0);
-
     buffer = "z";
 
 }
 
-SphericalCrownsCanopyParameters::SphericalCrownsCanopyParameters(){
+HomogeneousCanopyParameters::HomogeneousCanopyParameters(const pugi::xml_node canopy_node) : HomogeneousCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void HomogeneousCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    // ----- leaf size ------//
+    vec2 new_leaf_size = XMLloadvec2(canopy_node, "leaf_size");
+    if (new_leaf_size.x != nullvalue_f && new_leaf_size.y != nullvalue_f) {
+        leaf_size = new_leaf_size;
+    }
+
+    // ----- leaf subdivisions ------//
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    // ----- leaf color ------//
+    RGBAcolor new_leaf_color = XMLloadrgba(canopy_node, "leaf_color");
+    if (new_leaf_color.a != 0) {
+        leaf_color = make_RGBcolor(new_leaf_color.r, new_leaf_color.g, new_leaf_color.b);
+    }
+
+    // ----- leaf texture file ------//
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if (new_leaf_texture_file != nullvalue_s) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    // ----- leaf area index ------//
+    float LAI = XMLloadfloat(canopy_node, "leaf_area_index");
+    if (LAI != nullvalue_f) {
+        leaf_area_index = LAI;
+    }
+
+    // ----- canopy height ------//
+    float h = XMLloadfloat(canopy_node, "canopy_height");
+    if (h != nullvalue_f) {
+        canopy_height = h;
+    }
+
+    // ----- canopy extent ------//
+    vec2 new_canopy_extent = XMLloadvec2(canopy_node, "canopy_extent");
+    if (new_canopy_extent.x != nullvalue_f && new_canopy_extent.y != nullvalue_f) {
+        canopy_extent = new_canopy_extent;
+    }
+
+    // ----- buffer ------//
+    std::string new_buffer = XMLloadstring(canopy_node, "buffer");
+    if ( new_buffer != nullvalue_s ) {
+        buffer = new_buffer;
+    }
+}
+
+void HomogeneousCanopyParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    std::cout << "HomogeneousCanopyParameters::buildPlant: Cannot build a single plant of canopy type HomogeneousCanopyParameters" << std::endl;
+}
+
+void HomogeneousCanopyParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+SphericalCrownsCanopyParameters::SphericalCrownsCanopyParameters() : BaseCanopyParameters(){
 
     leaf_size = make_vec2(0.025,0.025);
 
@@ -60,13 +152,85 @@ SphericalCrownsCanopyParameters::SphericalCrownsCanopyParameters(){
 
     plant_count = make_int2(5,5);
 
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0.f;
-
 }
 
-ConicalCrownsCanopyParameters::ConicalCrownsCanopyParameters(){
+SphericalCrownsCanopyParameters::SphericalCrownsCanopyParameters(const pugi::xml_node canopy_node) : SphericalCrownsCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void SphericalCrownsCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    // ----- leaf size ------//
+    vec2 new_leaf_size = XMLloadvec2(canopy_node, "leaf_size");
+    if (new_leaf_size.x != nullvalue_f && new_leaf_size.y != nullvalue_f) {
+        leaf_size = new_leaf_size;
+    }
+
+    // ----- leaf subdivisions ------//
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    // ----- leaf color ------//
+    RGBAcolor new_leaf_color = XMLloadrgba(canopy_node, "leaf_color");
+    if (new_leaf_color.a != 0) {
+        leaf_color = make_RGBcolor(new_leaf_color.r, new_leaf_color.g, new_leaf_color.b);
+    }
+
+    // ----- leaf texture file ------//
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if (new_leaf_texture_file != nullvalue_s) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    // ----- leaf angle distribution ------//
+    std::string new_leaf_angle_distribution = XMLloadstring(canopy_node, "leaf_angle_distribution");
+    if (new_leaf_angle_distribution != nullvalue_s) {
+        leaf_angle_distribution = new_leaf_angle_distribution;
+    }
+
+    // ----- leaf area density ------//
+    float new_leaf_area_density = XMLloadfloat(canopy_node, "leaf_area_density");
+    if (new_leaf_area_density != nullvalue_f) {
+        leaf_area_density = new_leaf_area_density;
+    }
+
+    // ----- crown radius ------//
+    vec3 new_crown_radius = XMLloadvec3(canopy_node, "crown_radius");
+    if (new_crown_radius.x != nullvalue_f && new_crown_radius.y != nullvalue_f) {
+        crown_radius = new_crown_radius;
+    }
+
+    // ----- canopy configuration ------//
+    std::string new_canopy_configuration = XMLloadstring(canopy_node, "canopy_configuration");
+    if (new_canopy_configuration != nullvalue_s) {
+        canopy_configuration = new_canopy_configuration;
+    }
+
+    // ----- plant spacing ------//
+    vec2 new_plant_spacing = XMLloadvec2(canopy_node, "plant_spacing");
+    if (new_plant_spacing.x != nullvalue_f && new_plant_spacing.y != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    // ----- plant count ------//
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void SphericalCrownsCanopyParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    std::cout << "SphericalCrownsCanopyParameters::buildPlant: Cannot build a single plant of canopy type SphericalCrownsCanopyParameters" << std::endl;
+}
+
+void SphericalCrownsCanopyParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+ConicalCrownsCanopyParameters::ConicalCrownsCanopyParameters() : BaseCanopyParameters(){
 
     leaf_size = make_vec2(0.025,0.025);
 
@@ -88,23 +252,230 @@ ConicalCrownsCanopyParameters::ConicalCrownsCanopyParameters(){
 
     plant_count = make_int2(5,5);
 
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0.f;
-
 }
 
-VSPGrapevineParameters::VSPGrapevineParameters(){
+ConicalCrownsCanopyParameters::ConicalCrownsCanopyParameters(const pugi::xml_node canopy_node) : ConicalCrownsCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
 
-    leaf_width = 0.18;
+void ConicalCrownsCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
 
-    leaf_subdivisions = make_int2(1,1);
+    // ----- leaf size ------//
+    vec2 new_leaf_size = XMLloadvec2(canopy_node, "leaf_size");
+    if (new_leaf_size.x != nullvalue_f && new_leaf_size.y != nullvalue_f) {
+        leaf_size = new_leaf_size;
+    }
+
+    // ----- leaf subdivisions ------//
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    // ----- leaf color ------//
+    RGBAcolor new_leaf_color = XMLloadrgba(canopy_node, "leaf_color");
+    if (new_leaf_color.a != 0) {
+        leaf_color = make_RGBcolor(new_leaf_color.r, new_leaf_color.g, new_leaf_color.b);
+    }
+
+    // ----- leaf texture file ------//
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if (new_leaf_texture_file != nullvalue_s) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    // ----- leaf angle distribution ------//
+    std::string new_leaf_angle_distribution = XMLloadstring(canopy_node, "leaf_angle_distribution");
+    if (new_leaf_angle_distribution != nullvalue_s) {
+        leaf_angle_distribution = new_leaf_angle_distribution;
+    }
+
+    // ----- leaf area density ------//
+    float new_leaf_area_density = XMLloadfloat(canopy_node, "leaf_area_density");
+    if (new_leaf_area_density != nullvalue_f) {
+        leaf_area_density = new_leaf_area_density;
+    }
+
+    // ----- crown radius ------//
+    float new_crown_radius = XMLloadfloat(canopy_node, "crown_radius");
+    if (new_crown_radius != nullvalue_f) {
+        crown_radius = new_crown_radius;
+    }
+
+    // ----- crown height ------//
+    float new_crown_height = XMLloadfloat(canopy_node, "crown_height");
+    if (new_crown_height != nullvalue_f) {
+        crown_height = new_crown_height;
+    }
+
+    // ----- canopy configuration ------//
+    std::string new_canopy_configuration = XMLloadstring(canopy_node, "canopy_configuration");
+    if (new_canopy_configuration != nullvalue_s) {
+        canopy_configuration = new_canopy_configuration;
+    }
+
+    // ----- plant spacing ------//
+    vec2 new_plant_spacing = XMLloadvec2(canopy_node, "plant_spacing");
+    if (new_plant_spacing.x != nullvalue_f && new_plant_spacing.y != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    // ----- plant count ------//
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void ConicalCrownsCanopyParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    std::cout << "ConicalCrownsCanopyParameters::buildPlant: Cannot build a single plant of canopy type ConicalCrownsCanopyParameters" << std::endl;
+}
+
+void ConicalCrownsCanopyParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+BaseGrapeVineParameters::BaseGrapeVineParameters() : BaseCanopyParameters(){
 
     leaf_texture_file = "plugins/canopygenerator/textures/GrapeLeaf.png";
 
     wood_texture_file = "plugins/canopygenerator/textures/wood.jpg";
 
+    leaf_width = 0.18;
+
+    leaf_subdivisions = make_int2(1,1);
+
     wood_subdivisions = 10;
+
+    grape_color = make_RGBcolor(0.18,0.2,0.25);
+
+    plant_count = make_int2(3,3);
+
+}
+
+BaseGrapeVineParameters::BaseGrapeVineParameters(const pugi::xml_node canopy_node) : BaseGrapeVineParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    float new_leaf_width = XMLloadfloat(canopy_node, "leaf_width");
+    if (new_leaf_width != nullvalue_f) {
+        leaf_width = new_leaf_width;
+    }
+
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if ( new_leaf_texture_file != nullvalue_s ) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    std::string new_wood_texture_file = XMLloadstring(canopy_node, "wood_texture_file");
+    if ( new_wood_texture_file != nullvalue_s ) {
+        wood_texture_file = new_wood_texture_file;
+    }
+
+    int new_wood_subdivisions = XMLloadint(canopy_node, "wood_subdivisions");
+    if ( new_wood_subdivisions != nullvalue_i) {
+        wood_subdivisions = new_wood_subdivisions;
+    }
+
+    float h = XMLloadfloat(canopy_node, "trunk_height");
+    if (h != nullvalue_f) {
+        trunk_height = h;
+    }
+
+    float r = XMLloadfloat(canopy_node, "trunk_radius");
+    if (r != nullvalue_f) {
+        trunk_radius = r;
+    }
+
+    float ch = XMLloadfloat(canopy_node, "cordon_height");
+    if (ch != nullvalue_f) {
+        cordon_height = ch;
+    }
+
+    float cr = XMLloadfloat(canopy_node, "cordon_radius");
+    if (cr != nullvalue_f) {
+        cordon_radius = cr;
+    }
+
+    float sl = XMLloadfloat(canopy_node, "shoot_length");
+    if (sl != nullvalue_f) {
+        shoot_length = sl;
+    }
+
+    float sr = XMLloadfloat(canopy_node, "shoot_radius");
+    if (sr != nullvalue_f) {
+        shoot_radius = sr;
+    }
+
+    int spc = XMLloadint(canopy_node, "shoots_per_cordon");
+    if (spc != nullvalue_i) {
+        shoots_per_cordon = uint(spc);
+    }
+
+    float lsf = XMLloadfloat(canopy_node, "leaf_spacing_fraction");
+    if (lsf != nullvalue_f) {
+        leaf_spacing_fraction = lsf;
+    }
+
+    float gr = XMLloadfloat(canopy_node, "grape_radius");
+    if (gr != nullvalue_f) {
+        grape_radius = gr;
+    }
+
+    float clr = XMLloadfloat(canopy_node, "cluster_radius");
+    if (clr != nullvalue_f) {
+        cluster_radius = clr;
+    }
+
+    float clhm = XMLloadfloat(canopy_node, "cluster_height_max");
+    if (clhm != nullvalue_f) {
+        cluster_height_max = clhm;
+    }
+
+    RGBAcolor new_grape_color = XMLloadrgba(canopy_node, "grape_color");
+    if ( new_grape_color.a != 0 ) {
+        grape_color = make_RGBcolor(new_grape_color.r, new_grape_color.g, new_grape_color.b);
+    }
+
+    int new_grape_subdivisions = XMLloadint(canopy_node, "grape_subdivisions");
+    if (new_grape_subdivisions != nullvalue_i) {
+        grape_subdivisions = uint(new_grape_subdivisions);
+    }
+
+    float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
+    if (new_plant_spacing != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
+    if (new_row_spacing != nullvalue_f) {
+        row_spacing = new_row_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void BaseGrapeVineParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    std::cout << "BaseGrapeVineParameters::buildPlant: Cannot build a single plant of canopy type BaseGrapeVineParameters" << std::endl;
+}
+
+void BaseGrapeVineParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    std::cout << "BaseGrapeVineParameters::buildPlant: Cannot build a canopy of type BaseGrapeVineParameters" << std::endl;
+}
+
+VSPGrapevineParameters::VSPGrapevineParameters() : BaseGrapeVineParameters(){
 
     trunk_height = 0.7;
 
@@ -128,33 +499,31 @@ VSPGrapevineParameters::VSPGrapevineParameters(){
 
     cluster_height_max = 0.15;
 
-    grape_color = make_RGBcolor(0.18,0.2,0.25);
-
     grape_subdivisions = 8;
 
     plant_spacing = 2;
 
     row_spacing = 2;
 
-    plant_count = make_int2(3,3);
-
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-SplitGrapevineParameters::SplitGrapevineParameters(){
+VSPGrapevineParameters::VSPGrapevineParameters(const pugi::xml_node canopy_node) : VSPGrapevineParameters(){
+    readParametersFromXML(canopy_node);
+}
 
-    leaf_width = 0.18;
+void VSPGrapevineParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseGrapeVineParameters::readParametersFromXML(canopy_node);
+}
 
-    leaf_subdivisions = make_int2(1,1);
+void VSPGrapevineParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.grapevineVSP(*this, origin);
+}
 
-    leaf_texture_file = "plugins/canopygenerator/textures/GrapeLeaf.png";
+void VSPGrapevineParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
 
-    wood_texture_file = "plugins/canopygenerator/textures/wood.jpg";
-
-    wood_subdivisions = 10;
+SplitGrapevineParameters::SplitGrapevineParameters() : BaseGrapeVineParameters(){
 
     trunk_height = 1.3;
 
@@ -184,33 +553,46 @@ SplitGrapevineParameters::SplitGrapevineParameters(){
 
     cluster_height_max = 0.1;
 
-    grape_color = make_RGBcolor(0.18,0.2,0.25);
-
     grape_subdivisions = 8;
 
     plant_spacing = 2;
 
     row_spacing = 4;
 
-    plant_count = make_int2(3,3);
-
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-UnilateralGrapevineParameters::UnilateralGrapevineParameters(){
+SplitGrapevineParameters::SplitGrapevineParameters(const pugi::xml_node canopy_node) : SplitGrapevineParameters(){
+    readParametersFromXML(canopy_node);
+}
 
-    leaf_width = 0.18;
+void SplitGrapevineParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseGrapeVineParameters::readParametersFromXML(canopy_node);
 
-    leaf_subdivisions = make_int2(1,1);
+    float cs = XMLloadfloat(canopy_node, "cordon_spacing");
+    if (cs != nullvalue_f) {
+        cordon_spacing = cs;
+    }
 
-    leaf_texture_file = "plugins/canopygenerator/textures/GrapeLeaf.png";
+    float sat = XMLloadfloat( canopy_node, "shoot_angle_tip" );
+    if( sat != nullvalue_f ){
+        shoot_angle_tip = sat;
+    }
 
-    wood_texture_file = "plugins/canopygenerator/textures/wood.jpg";
+    float sab = XMLloadfloat( canopy_node, "shoot_angle_base" );
+    if( sab != nullvalue_f ){
+        shoot_angle_base = sab;
+    }
+}
 
-    wood_subdivisions = 10;
+void SplitGrapevineParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.grapevineSplit(*this, origin);
+}
+
+void SplitGrapevineParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+UnilateralGrapevineParameters::UnilateralGrapevineParameters() : BaseGrapeVineParameters(){
 
     trunk_height = 0.7;
 
@@ -234,33 +616,31 @@ UnilateralGrapevineParameters::UnilateralGrapevineParameters(){
 
     cluster_height_max = 0.1;
 
-    grape_color = make_RGBcolor(0.18,0.2,0.25);
-
     grape_subdivisions = 8;
 
     plant_spacing = 1.5;
 
     row_spacing = 2;
 
-    plant_count = make_int2(3,3);
-
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-GobletGrapevineParameters::GobletGrapevineParameters(){
+UnilateralGrapevineParameters::UnilateralGrapevineParameters(const pugi::xml_node canopy_node) : UnilateralGrapevineParameters(){
+    readParametersFromXML(canopy_node);
+}
 
-    leaf_width = 0.18;
+void UnilateralGrapevineParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseGrapeVineParameters::readParametersFromXML(canopy_node);
+}
 
-    leaf_subdivisions = make_int2(1,1);
+void UnilateralGrapevineParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.grapevineUnilateral(*this, origin);
+}
 
-    leaf_texture_file = "plugins/canopygenerator/textures/GrapeLeaf.png";
+void UnilateralGrapevineParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
 
-    wood_texture_file = "plugins/canopygenerator/textures/wood.jpg";
-
-    wood_subdivisions = 10;
+GobletGrapevineParameters::GobletGrapevineParameters() : BaseGrapeVineParameters(){
 
     trunk_height = 0.7;
 
@@ -284,23 +664,31 @@ GobletGrapevineParameters::GobletGrapevineParameters(){
 
     cluster_height_max = 0.1;
 
-    grape_color = make_RGBcolor(0.18,0.2,0.25);
-
     grape_subdivisions = 8;
 
     plant_spacing = 2;
 
     row_spacing = 2;
 
-    plant_count = make_int2(3,3);
-
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-WhiteSpruceCanopyParameters::WhiteSpruceCanopyParameters(){
+GobletGrapevineParameters::GobletGrapevineParameters(const pugi::xml_node canopy_node) : GobletGrapevineParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void GobletGrapevineParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseGrapeVineParameters::readParametersFromXML(canopy_node);
+}
+
+void GobletGrapevineParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.grapevineGoblet(*this, origin);
+}
+
+void GobletGrapevineParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+WhiteSpruceCanopyParameters::WhiteSpruceCanopyParameters() : BaseCanopyParameters(){
 
     needle_width = 0.0005;
 
@@ -336,13 +724,105 @@ WhiteSpruceCanopyParameters::WhiteSpruceCanopyParameters(){
 
     plant_count = make_int2(3,3);
 
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-TomatoParameters::TomatoParameters(){
+WhiteSpruceCanopyParameters::WhiteSpruceCanopyParameters(const pugi::xml_node canopy_node) : WhiteSpruceCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void WhiteSpruceCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    float new_needle_width = XMLloadfloat(canopy_node, "needle_width");
+    if (new_needle_width != nullvalue_f) {
+        needle_width = new_needle_width;
+    }
+
+    float new_needle_length = XMLloadfloat(canopy_node, "needle_length");
+    if (new_needle_length != nullvalue_f) {
+        needle_length = new_needle_length;
+    }
+
+    int2 new_needle_subdivisions = XMLloadint2(canopy_node, "needle_subdivisions");
+    if (new_needle_subdivisions.x != nullvalue_i && new_needle_subdivisions.y != nullvalue_i) {
+        needle_subdivisions = new_needle_subdivisions;
+    }
+
+    RGBAcolor new_needle_color = XMLloadrgba(canopy_node, "needle_color");
+    if (new_needle_color.a != 0) {
+        needle_color = make_RGBcolor(new_needle_color.r, new_needle_color.g, new_needle_color.b);
+    }
+
+    std::string new_wood_texture_file = XMLloadstring(canopy_node, "wood_texture_file");
+    if ( new_wood_texture_file != nullvalue_s ) {
+        wood_texture_file = new_wood_texture_file;
+    }
+
+    int new_wood_subdivisions = XMLloadint(canopy_node, "wood_subdivisions");
+    if (new_wood_subdivisions != nullvalue_i) {
+        wood_subdivisions = new_wood_subdivisions;
+    }
+
+    float new_trunk_height = XMLloadfloat(canopy_node, "trunk_height");
+    if (new_trunk_height != nullvalue_f) {
+        trunk_height = new_trunk_height;
+    }
+
+    float new_trunk_radius = XMLloadfloat(canopy_node, "trunk_radius");
+    if (new_trunk_radius != nullvalue_f) {
+        trunk_radius = new_trunk_radius;
+    }
+
+    float new_crown_radius = XMLloadfloat(canopy_node, "crown_radius");
+    if (new_crown_radius != nullvalue_f) {
+        crown_radius = new_crown_radius;
+    }
+
+    float new_shoot_radius = XMLloadfloat(canopy_node, "shoot_radius");
+    if (new_shoot_radius != nullvalue_f) {
+        shoot_radius = new_shoot_radius;
+    }
+
+    float new_level_spacing = XMLloadfloat(canopy_node, "level_spacing");
+    if (new_level_spacing != nullvalue_f) {
+        level_spacing = new_level_spacing;
+    }
+
+    int new_branches_per_level = XMLloadint(canopy_node, "branches_per_level");
+    if (new_branches_per_level != nullvalue_i) {
+        branches_per_level = new_branches_per_level;
+    }
+
+    float new_shoot_angle = XMLloadfloat(canopy_node, "shoot_angle");
+    if (new_shoot_angle != nullvalue_f) {
+        shoot_angle = new_shoot_angle;
+    }
+
+    std::string new_canopy_configuration = XMLloadstring(canopy_node, "canopy_configuration");
+    if (new_canopy_configuration != nullvalue_s) {
+        canopy_configuration = new_canopy_configuration;
+    }
+
+    vec2 new_plant_spacing = XMLloadvec2(canopy_node, "plant_spacing");
+    if (new_plant_spacing.x != nullvalue_f && new_plant_spacing.y != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void WhiteSpruceCanopyParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.whitespruce(*this, origin);
+}
+
+void WhiteSpruceCanopyParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+TomatoParameters::TomatoParameters() : BaseCanopyParameters(){
 
     leaf_length = 0.2;
 
@@ -368,13 +848,86 @@ TomatoParameters::TomatoParameters(){
 
     plant_count = make_int2(3,3);
 
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-StrawberryParameters::StrawberryParameters(){
+TomatoParameters::TomatoParameters(const pugi::xml_node canopy_node) : TomatoParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void TomatoParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    float new_leaf_length = XMLloadfloat(canopy_node, "leaf_length");
+    if (new_leaf_length != nullvalue_f) {
+        leaf_length = new_leaf_length;
+    }
+
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if ( new_leaf_texture_file != nullvalue_s ) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    RGBAcolor new_shoot_color = XMLloadrgba(canopy_node, "shoot_color");
+    if (new_shoot_color.a != 0 ) {
+        shoot_color = make_RGBcolor(new_shoot_color.r, new_shoot_color.g, new_shoot_color.b);
+    }
+
+    int new_shoot_subdivisions = XMLloadint(canopy_node, "shoot_subdivisions");
+    if (new_shoot_subdivisions != nullvalue_i) {
+        shoot_subdivisions = new_shoot_subdivisions;
+    }
+
+    float h = XMLloadfloat(canopy_node, "plant_height");
+    if (h != nullvalue_f) {
+        plant_height = h;
+    }
+
+    float gr = XMLloadfloat(canopy_node, "fruit_radius");
+    if (gr != nullvalue_f) {
+        fruit_radius = gr;
+    }
+
+    RGBAcolor new_fruit_color = XMLloadrgba(canopy_node, "fruit_color");
+    if (new_fruit_color.a != 0 ) {
+        fruit_color = make_RGBcolor(new_fruit_color.r, new_fruit_color.g, new_fruit_color.b);
+    }
+
+
+    int new_fruit_subdivisions = XMLloadint(canopy_node, "fruit_subdivisions");
+    if (new_fruit_subdivisions != nullvalue_i) {
+        fruit_subdivisions = uint(new_fruit_subdivisions);
+    }
+
+    float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
+    if (new_plant_spacing != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
+    if (new_row_spacing != nullvalue_f) {
+        row_spacing = new_row_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void TomatoParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.tomato(*this, origin);
+}
+
+void TomatoParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+StrawberryParameters::StrawberryParameters() : BaseCanopyParameters(){
 
     leaf_length = 0.1;
 
@@ -406,13 +959,95 @@ StrawberryParameters::StrawberryParameters(){
 
     plant_count = make_int2(4,2);
 
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-WalnutCanopyParameters::WalnutCanopyParameters(){
+StrawberryParameters::StrawberryParameters(const pugi::xml_node canopy_node) : StrawberryParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void StrawberryParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    float new_leaf_length = XMLloadfloat(canopy_node, "leaf_length");
+    if (new_leaf_length != nullvalue_f) {
+        leaf_length = new_leaf_length;
+    }
+
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if ( new_leaf_texture_file != nullvalue_s ) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    int new_stem_subdivisions = XMLloadint(canopy_node, "stem_subdivisions");
+    if (new_stem_subdivisions != nullvalue_i) {
+        stem_subdivisions = new_stem_subdivisions;
+    }
+
+    float new_stem_radius = XMLloadfloat(canopy_node, "stem_radius");
+    if (new_stem_radius != nullvalue_f) {
+        stem_radius = new_stem_radius;
+    }
+
+    float h = XMLloadfloat(canopy_node, "plant_height");
+    if (h != nullvalue_f) {
+        plant_height = h;
+    }
+
+    int r = XMLloadint(canopy_node, "stems_per_plant");
+    if (r != nullvalue_i) {
+        stems_per_plant = r;
+    }
+
+    float gr = XMLloadfloat(canopy_node, "fruit_radius");
+    if (gr != nullvalue_f) {
+        fruit_radius = gr;
+    }
+
+    float clr = XMLloadfloat(canopy_node, "clusters_per_stem");
+    if (clr != nullvalue_f) {
+        clusters_per_stem = clr;
+    }
+
+    int new_fruit_subdivisions = XMLloadint(canopy_node, "fruit_subdivisions");
+    if (new_fruit_subdivisions != nullvalue_i) {
+        fruit_subdivisions = uint(new_fruit_subdivisions);
+    }
+
+    std::string new_fruit_texture_file = XMLloadstring(canopy_node, "fruit_texture_file");
+    if ( new_fruit_texture_file != nullvalue_s ) {
+        fruit_texture_file = new_fruit_texture_file;
+    }
+
+    float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
+    if (new_plant_spacing != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
+    if (new_row_spacing != nullvalue_f) {
+        row_spacing = new_row_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = plant_count;
+    }
+}
+
+void StrawberryParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.strawberry(*this, origin);
+}
+
+void StrawberryParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+WalnutCanopyParameters::WalnutCanopyParameters() : BaseCanopyParameters(){
 
     leaf_length = 0.15;
 
@@ -442,13 +1077,86 @@ WalnutCanopyParameters::WalnutCanopyParameters(){
 
     plant_count = make_int2(4,2);
 
-    canopy_origin = make_vec3(0,0,0);
-
-    canopy_rotation = 0;
-
 }
 
-SorghumCanopyParameters::SorghumCanopyParameters(){
+WalnutCanopyParameters::WalnutCanopyParameters(const pugi::xml_node canopy_node) : WalnutCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void WalnutCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    float new_leaf_length = XMLloadfloat(canopy_node, "leaf_length");
+    if (new_leaf_length != nullvalue_f) {
+        leaf_length = new_leaf_length;
+    }
+
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if ( new_leaf_texture_file != nullvalue_s ) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    int new_wood_subdivisions = XMLloadint(canopy_node, "wood_subdivisions");
+    if (new_wood_subdivisions != nullvalue_i) {
+        wood_subdivisions = new_wood_subdivisions;
+    }
+
+
+    float new_trunk_radius = XMLloadfloat(canopy_node, "trunk_radius");
+    if (new_trunk_radius != nullvalue_f) {
+        trunk_radius = new_trunk_radius;
+    }
+
+    float new_trunk_height = XMLloadfloat(canopy_node, "trunk_height");
+    if (new_trunk_height != nullvalue_f) {
+        trunk_height = new_trunk_height;
+    }
+
+    vec3 new_branch_length = XMLloadvec3(canopy_node, "branch_length");
+    if (new_branch_length.x != nullvalue_f && new_branch_length.y != nullvalue_f) {
+        branch_length = new_branch_length;
+    }
+
+    std::string new_fruit_texture_file = XMLloadstring(canopy_node, "fruit_texture_file");
+    if ( new_fruit_texture_file != nullvalue_s ) {
+        fruit_texture_file = new_fruit_texture_file;
+    }
+
+    int new_fruit_subdivisions = XMLloadint(canopy_node, "fruit_subdivisions");
+    if (new_fruit_subdivisions != nullvalue_i) {
+        fruit_subdivisions = uint(new_fruit_subdivisions);
+    }
+
+    float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
+    if (new_plant_spacing != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
+    if (new_row_spacing != nullvalue_f) {
+        row_spacing = new_row_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void WalnutCanopyParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.walnut(*this, origin);
+}
+
+void WalnutCanopyParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+SorghumCanopyParameters::SorghumCanopyParameters() : BaseCanopyParameters(){
     sorghum_stage = 5;
 
     // stage 1
@@ -578,10 +1286,335 @@ SorghumCanopyParameters::SorghumCanopyParameters(){
 
     plant_count = make_int2(10 ,10);
 
-    canopy_origin = make_vec3(0,0,0);
 }
 
-BeanParameters::BeanParameters() {
+SorghumCanopyParameters::SorghumCanopyParameters(const pugi::xml_node canopy_node) : SorghumCanopyParameters(){
+    readParametersFromXML(canopy_node);
+}
+
+void SorghumCanopyParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    int new_sorghum_stage = XMLloadint(canopy_node, "sorghum_stage");
+    if (new_sorghum_stage != nullvalue_i) {
+        sorghum_stage = new_sorghum_stage;
+    }
+
+    // STAGE 1
+    float new_s1_stem_length = XMLloadint(canopy_node, "s1_stem_length");
+    if (new_s1_stem_length != nullvalue_i) {
+        s1_stem_length = new_s1_stem_length;
+    }
+
+    float new_s1_stem_radius = XMLloadfloat(canopy_node, "s1_stem_radius");
+    if (new_s1_stem_radius != nullvalue_f) {
+        s1_stem_radius = new_s1_stem_radius;
+    }
+
+    int new_s1_stem_subdivisions = XMLloadint(canopy_node, "s1_stem_subdivisions");
+    if (new_s1_stem_subdivisions != nullvalue_f) {
+        s1_stem_subdivisions = uint(new_s1_stem_subdivisions);
+    }
+
+    vec2 new_s1_leaf_size1 = XMLloadvec2(canopy_node, "s1_leaf_size1");
+    if (new_s1_leaf_size1.x != nullvalue_f && new_s1_leaf_size1.y != nullvalue_f) {
+        s1_leaf_size1 = new_s1_leaf_size1;
+    }
+
+    vec2 new_s1_leaf_size2 = XMLloadvec2(canopy_node, "s1_leaf_size2");
+    if (new_s1_leaf_size2.x != nullvalue_f && new_s1_leaf_size2.y != nullvalue_f) {
+        s1_leaf_size2 = new_s1_leaf_size2;
+    }
+
+    vec2 new_s1_leaf_size3 = XMLloadvec2(canopy_node, "s1_leaf_size3");
+    if (new_s1_leaf_size3.x != nullvalue_f && new_s1_leaf_size3.y != nullvalue_f) {
+        s1_leaf_size3 = new_s1_leaf_size3;
+    }
+
+    float new_s1_leaf1_angle = XMLloadfloat(canopy_node, "s1_leaf1_angle");
+    if (new_s1_leaf1_angle != nullvalue_f) {
+        s1_leaf1_angle = new_s1_leaf1_angle;
+    }
+
+    float new_s1_leaf2_angle = XMLloadfloat(canopy_node, "s1_leaf2_angle");
+    if (new_s1_leaf2_angle != nullvalue_f) {
+        s1_leaf2_angle = new_s1_leaf2_angle;
+    }
+
+    float new_s1_leaf3_angle = XMLloadfloat(canopy_node, "s1_leaf3_angle");
+    if (new_s1_leaf3_angle != nullvalue_f) {
+        s1_leaf3_angle = new_s1_leaf3_angle;
+    }
+
+    int2 new_s1_leaf_subdivisions = XMLloadint2(canopy_node, "s1_leaf_subdivisions");
+    if (new_s1_leaf_subdivisions.x != nullvalue_i && new_s1_leaf_subdivisions.y != nullvalue_i) {
+        s1_leaf_subdivisions = new_s1_leaf_subdivisions;
+    }
+
+    std::string new_s1_leaf_texture_file = XMLloadstring(canopy_node, "s1_leaf_texture_file");
+    if (new_s1_leaf_texture_file.compare(nullvalue_s) != 0) {
+        s1_leaf_texture_file = new_s1_leaf_texture_file;
+    }
+
+    // STAGE 2
+    float new_s2_stem_length = XMLloadint(canopy_node, "s2_stem_length");
+    if (new_s2_stem_length != nullvalue_i) {
+        s2_stem_length = new_s2_stem_length;
+    }
+
+    float new_s2_stem_radius = XMLloadfloat(canopy_node, "s2_stem_radius");
+    if (new_s2_stem_radius != nullvalue_f) {
+        s2_stem_radius = new_s2_stem_radius;
+    }
+
+    int new_s2_stem_subdivisions = XMLloadint(canopy_node, "s2_stem_subdivisions");
+    if (new_s2_stem_subdivisions != nullvalue_f) {
+        s2_stem_subdivisions = uint(new_s2_stem_subdivisions);
+    }
+
+    vec2 new_s2_leaf_size1 = XMLloadvec2(canopy_node, "s2_leaf_size1");
+    if (new_s2_leaf_size1.x != nullvalue_f && new_s2_leaf_size1.y != nullvalue_f) {
+        s2_leaf_size1 = new_s2_leaf_size1;
+    }
+
+    vec2 new_s2_leaf_size2 = XMLloadvec2(canopy_node, "s2_leaf_size2");
+    if (new_s2_leaf_size2.x != nullvalue_f && new_s2_leaf_size2.y != nullvalue_f) {
+        s2_leaf_size2 = new_s2_leaf_size2;
+    }
+
+    vec2 new_s2_leaf_size3 = XMLloadvec2(canopy_node, "s2_leaf_size3");
+    if (new_s2_leaf_size3.x != nullvalue_f && new_s2_leaf_size3.y != nullvalue_f) {
+        s2_leaf_size3 = new_s2_leaf_size3;
+    }
+
+    vec2 new_s2_leaf_size4 = XMLloadvec2(canopy_node, "s2_leaf_size4");
+    if (new_s2_leaf_size4.x != nullvalue_f && new_s2_leaf_size4.y != nullvalue_f) {
+        s2_leaf_size4 = new_s2_leaf_size4;
+    }
+
+    vec2 new_s2_leaf_size5 = XMLloadvec2(canopy_node, "s2_leaf_size5");
+    if (new_s2_leaf_size5.x != nullvalue_f && new_s2_leaf_size5.y != nullvalue_f) {
+        s2_leaf_size5 = new_s2_leaf_size5;
+    }
+
+    float new_s2_leaf1_angle = XMLloadfloat(canopy_node, "s2_leaf1_angle");
+    if (new_s2_leaf1_angle != nullvalue_f) {
+        s2_leaf1_angle = new_s2_leaf1_angle;
+    }
+
+    float new_s2_leaf2_angle = XMLloadfloat(canopy_node, "s2_leaf2_angle");
+    if (new_s2_leaf2_angle != nullvalue_f) {
+        s2_leaf2_angle = new_s2_leaf2_angle;
+    }
+
+    float new_s2_leaf3_angle = XMLloadfloat(canopy_node, "s2_leaf3_angle");
+    if (new_s2_leaf3_angle != nullvalue_f) {
+        s2_leaf3_angle = new_s2_leaf3_angle;
+    }
+
+    float new_s2_leaf4_angle = XMLloadfloat(canopy_node, "s2_leaf4_angle");
+    if (new_s2_leaf4_angle != nullvalue_f) {
+        s2_leaf4_angle = new_s2_leaf4_angle;
+    }
+
+    float new_s2_leaf5_angle = XMLloadfloat(canopy_node, "s2_leaf5_angle");
+    if (new_s2_leaf3_angle != nullvalue_f) {
+        s2_leaf5_angle = new_s2_leaf5_angle;
+    }
+
+    int2 new_s2_leaf_subdivisions = XMLloadint2(canopy_node, "s2_leaf_subdivisions");
+    if (new_s2_leaf_subdivisions.x != nullvalue_i && new_s2_leaf_subdivisions.y != nullvalue_i) {
+        s2_leaf_subdivisions = new_s2_leaf_subdivisions;
+    }
+
+    std::string new_s2_leaf_texture_file = XMLloadstring(canopy_node, "s2_leaf_texture_file");
+    if (new_s2_leaf_texture_file.compare(nullvalue_s) != 0) {
+        s2_leaf_texture_file = new_s2_leaf_texture_file;
+    }
+
+    // STAGE 3
+    float new_s3_stem_length = XMLloadint(canopy_node, "s3_stem_length");
+    if (new_s3_stem_length != nullvalue_i) {
+        s3_stem_length = new_s3_stem_length;
+    }
+
+    float new_s3_stem_radius = XMLloadfloat(canopy_node, "s3_stem_radius");
+    if (new_s3_stem_radius != nullvalue_f) {
+        s3_stem_radius = new_s3_stem_radius;
+    }
+
+    int new_s3_stem_subdivisions = XMLloadint(canopy_node, "s3_stem_subdivisions");
+    if (new_s3_stem_subdivisions != nullvalue_f) {
+        s3_stem_subdivisions = uint(new_s3_stem_subdivisions);
+    }
+
+    vec2 new_s3_leaf_size = XMLloadvec2(canopy_node, "s3_leaf_size");
+    if (new_s3_leaf_size.x != nullvalue_f && new_s3_leaf_size.y != nullvalue_f) {
+        s3_leaf_size = new_s3_leaf_size;
+    }
+
+    int2 new_s3_leaf_subdivisions = XMLloadint2(canopy_node, "s3_leaf_subdivisions");
+    if (new_s3_leaf_subdivisions.x != nullvalue_i && new_s3_leaf_subdivisions.y != nullvalue_i) {
+        s3_leaf_subdivisions = new_s3_leaf_subdivisions;
+    }
+
+    int new_s3_number_of_leaves = XMLloadint(canopy_node, "s3_number_of_leaves");
+    if (new_s3_number_of_leaves != nullvalue_i) {
+        s3_number_of_leaves = new_s3_number_of_leaves;
+    }
+
+    float new_s3_mean_leaf_angle = XMLloadfloat(canopy_node, "s3_mean_leaf_angle");
+    if (new_s3_mean_leaf_angle != nullvalue_f) {
+        s3_mean_leaf_angle = new_s3_mean_leaf_angle;
+    }
+
+    std::string new_s3_leaf_texture_file = XMLloadstring(canopy_node, "s3_leaf_texture_file");
+    if (new_s3_leaf_texture_file.compare(nullvalue_s) != 0) {
+        s3_leaf_texture_file = new_s3_leaf_texture_file;
+    }
+
+    // STAGE 4
+    float new_s4_stem_length = XMLloadint(canopy_node, "s4_stem_length");
+    if (new_s4_stem_length != nullvalue_i) {
+        s4_stem_length = new_s4_stem_length;
+    }
+
+    float new_s4_stem_radius = XMLloadfloat(canopy_node, "s4_stem_radius");
+    if (new_s4_stem_radius != nullvalue_f) {
+        s4_stem_radius = new_s4_stem_radius;
+    }
+
+    int new_s4_stem_subdivisions = XMLloadint(canopy_node, "s4_stem_subdivisions");
+    if (new_s4_stem_subdivisions != nullvalue_f) {
+        s4_stem_subdivisions = uint(new_s4_stem_subdivisions);
+    }
+
+    vec2 new_s4_panicle_size = XMLloadvec2(canopy_node, "s4_panicle_size");
+    if (new_s4_panicle_size.x != nullvalue_f && new_s4_panicle_size.y != nullvalue_f) {
+        s4_panicle_size = new_s4_panicle_size;
+    }
+
+    int new_s4_panicle_subdivisions = XMLloadint(canopy_node, "s4_panicle_subdivisions");
+    if (new_s4_panicle_subdivisions != nullvalue_f) {
+        s4_panicle_subdivisions = uint(new_s4_panicle_subdivisions);
+    }
+
+    std::string new_s4_seed_texture_file = XMLloadstring(canopy_node, "s4_seed_texture_file");
+    if (new_s4_seed_texture_file.compare(nullvalue_s) != 0) {
+        s4_seed_texture_file = new_s4_seed_texture_file;
+    }
+
+    vec2 new_s4_leaf_size = XMLloadvec2(canopy_node, "s4_leaf_size");
+    if (new_s4_leaf_size.x != nullvalue_f && new_s4_leaf_size.y != nullvalue_f) {
+        s4_leaf_size = new_s4_leaf_size;
+    }
+
+    int2 new_s4_leaf_subdivisions = XMLloadint2(canopy_node, "s4_leaf_subdivisions");
+    if (new_s4_leaf_subdivisions.x != nullvalue_i && new_s4_leaf_subdivisions.y != nullvalue_i) {
+        s4_leaf_subdivisions = new_s4_leaf_subdivisions;
+    }
+
+    int new_s4_number_of_leaves = XMLloadint(canopy_node, "s4_number_of_leaves");
+    if (new_s4_number_of_leaves != nullvalue_i) {
+        s4_number_of_leaves = new_s4_number_of_leaves;
+    }
+
+    float new_s4_mean_leaf_angle = XMLloadfloat(canopy_node, "s4_mean_leaf_angle");
+    if (new_s4_mean_leaf_angle != nullvalue_f) {
+        s4_mean_leaf_angle = new_s4_mean_leaf_angle;
+    }
+
+    std::string new_s4_leaf_texture_file = XMLloadstring(canopy_node, "s4_leaf_texture_file");
+    if (new_s4_leaf_texture_file.compare(nullvalue_s) != 0) {
+        s4_leaf_texture_file = new_s4_leaf_texture_file;
+    }
+
+    // STAGE 5
+    float new_s5_stem_length = XMLloadint(canopy_node, "s5_stem_length");
+    if (new_s5_stem_length != nullvalue_i) {
+        s5_stem_length = new_s5_stem_length;
+    }
+
+    float new_s5_stem_radius = XMLloadfloat(canopy_node, "s5_stem_radius");
+    if (new_s5_stem_radius != nullvalue_f) {
+        s5_stem_radius = new_s5_stem_radius;
+    }
+
+    float new_s5_stem_bend = XMLloadfloat(canopy_node, "s5_stem_bend");
+    if (new_s5_stem_bend != nullvalue_f) {
+        s5_stem_bend = new_s5_stem_bend;
+    }
+
+    int new_s5_stem_subdivisions = XMLloadint(canopy_node, "s5_stem_subdivisions");
+    if (new_s5_stem_subdivisions != nullvalue_f) {
+        s5_stem_subdivisions = uint(new_s5_stem_subdivisions);
+    }
+
+    vec2 new_s5_panicle_size = XMLloadvec2(canopy_node, "s5_panicle_size");
+    if (new_s5_panicle_size.x != nullvalue_f && new_s5_panicle_size.y != nullvalue_f) {
+        s5_panicle_size = new_s5_panicle_size;
+    }
+
+    int new_s5_panicle_subdivisions = XMLloadint(canopy_node, "s5_panicle_subdivisions");
+    if (new_s5_panicle_subdivisions != nullvalue_f) {
+        s5_panicle_subdivisions = uint(new_s5_panicle_subdivisions);
+    }
+
+    std::string new_s5_seed_texture_file = XMLloadstring(canopy_node, "s5_seed_texture_file");
+    if (new_s5_seed_texture_file.compare(nullvalue_s) != 0) {
+        s5_seed_texture_file = new_s5_seed_texture_file;
+    }
+
+    vec2 new_s5_leaf_size = XMLloadvec2(canopy_node, "s5_leaf_size");
+    if (new_s5_leaf_size.x != nullvalue_f && new_s5_leaf_size.y != nullvalue_f) {
+        s5_leaf_size = new_s5_leaf_size;
+    }
+
+    int2 new_s5_leaf_subdivisions = XMLloadint2(canopy_node, "s5_leaf_subdivisions");
+    if (new_s5_leaf_subdivisions.x != nullvalue_i && new_s5_leaf_subdivisions.y != nullvalue_i) {
+        s5_leaf_subdivisions = new_s5_leaf_subdivisions;
+    }
+
+    int new_s5_number_of_leaves = XMLloadint(canopy_node, "s5_number_of_leaves");
+    if (new_s5_number_of_leaves != nullvalue_i) {
+        s5_number_of_leaves = new_s5_number_of_leaves;
+    }
+
+    float new_s5_mean_leaf_angle = XMLloadfloat(canopy_node, "s5_mean_leaf_angle");
+    if (new_s5_mean_leaf_angle != nullvalue_f) {
+        s5_mean_leaf_angle = new_s5_mean_leaf_angle;
+    }
+
+    std::string new_s5_leaf_texture_file = XMLloadstring(canopy_node, "s5_leaf_texture_file");
+    if (new_s5_leaf_texture_file.compare(nullvalue_s) != 0) {
+        s5_leaf_texture_file = new_s5_leaf_texture_file;
+    }
+
+    float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
+    if (new_plant_spacing != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
+    if (new_row_spacing != nullvalue_f) {
+        row_spacing = new_row_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+}
+
+void SorghumCanopyParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.sorghum(*this, origin);
+}
+
+void SorghumCanopyParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
+}
+
+BeanParameters::BeanParameters() : BaseCanopyParameters() {
 
   leaf_length = 0.075;
 
@@ -613,10 +1646,97 @@ BeanParameters::BeanParameters() {
 
   germination_probability = 1.f;
 
-  canopy_origin = make_vec3(0, 0, 0);
+}
 
-  canopy_rotation = 0;
+BeanParameters::BeanParameters(const pugi::xml_node canopy_node) : BeanParameters(){
+    readParametersFromXML(canopy_node);
+}
 
+void BeanParameters::readParametersFromXML(const pugi::xml_node canopy_node){
+    BaseCanopyParameters::readParametersFromXML(canopy_node);
+
+    float new_leaf_length = XMLloadfloat(canopy_node, "leaf_length");
+    if (new_leaf_length != nullvalue_f) {
+        leaf_length = new_leaf_length;
+    }
+
+    int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
+    if (new_leaf_subdivisions.x != nullvalue_i && new_leaf_subdivisions.y != nullvalue_i) {
+        leaf_subdivisions = new_leaf_subdivisions;
+    }
+
+    std::string new_leaf_texture_file = XMLloadstring(canopy_node, "leaf_texture_file");
+    if ( new_leaf_texture_file != nullvalue_s ) {
+        leaf_texture_file = new_leaf_texture_file;
+    }
+
+    int new_shoot_subdivisions = XMLloadint(canopy_node, "shoot_subdivisions");
+    if (new_shoot_subdivisions != nullvalue_i) {
+        shoot_subdivisions = new_shoot_subdivisions;
+    }
+
+    float new_stem_radius = XMLloadfloat(canopy_node, "stem_radius");
+    if (new_stem_radius != nullvalue_f) {
+        stem_radius = new_stem_radius;
+    }
+
+    RGBAcolor new_shoot_color = XMLloadrgba(canopy_node, "shoot_color");
+    if( new_shoot_color.a != 0 ){
+        shoot_color = make_RGBcolor(new_shoot_color.r, new_shoot_color.g, new_shoot_color.b);
+    }
+
+    float new_stem_length = XMLloadfloat(canopy_node, "stem_length");
+    if (new_stem_length != nullvalue_f ) {
+        stem_length = new_stem_length;
+    }
+
+    float new_leaflet_length = XMLloadfloat(canopy_node, "leaflet_length");
+    if (new_leaflet_length != nullvalue_f ) {
+        leaflet_length = new_leaflet_length;
+    }
+
+    float new_pod_length = XMLloadfloat(canopy_node, "pod_length");
+    if (new_pod_length != nullvalue_f ) {
+        pod_length = new_pod_length;
+    }
+
+    RGBAcolor new_pod_color = XMLloadrgba(canopy_node, "pod_color");
+    if( new_pod_color.a != 0 ){
+        pod_color = make_RGBcolor(new_pod_color.r, new_pod_color.g, new_pod_color.b);
+    }
+
+    int new_pod_subdivisions = XMLloadint(canopy_node, "pod_subdivisions");
+    if (new_pod_subdivisions != nullvalue_i ) {
+        pod_subdivisions = new_pod_subdivisions;
+    }
+
+    float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
+    if (new_plant_spacing != nullvalue_f) {
+        plant_spacing = new_plant_spacing;
+    }
+
+    float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
+    if (new_row_spacing != nullvalue_f) {
+        row_spacing = new_row_spacing;
+    }
+
+    int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
+    if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
+        plant_count = new_plant_count;
+    }
+
+    float new_germination_probability = XMLloadfloat(canopy_node, "germination_probability");
+    if (new_germination_probability != nullvalue_f) {
+        germination_probability = new_germination_probability;
+    }
+}
+
+void BeanParameters::buildPlant(CanopyGenerator& canopy_generator, helios::vec3 origin){
+    canopy_generator.bean(*this, origin);
+}
+
+void BeanParameters::buildCanopy(CanopyGenerator& canopy_generator){
+    canopy_generator.buildCanopy(*this);
 }
 
   CanopyGenerator::CanopyGenerator( helios::Context* m_context ){
@@ -780,15 +1900,25 @@ int CanopyGenerator::selfTest(){
 
 }
 
-void CanopyGenerator::loadXML( const char* filename ){
+template <typename CanopyType, typename... Args>
+void CanopyGenerator::storeCanopyParameters(Args&&... args){
+    static_assert(std::is_base_of<BaseCanopyParameters, CanopyType>::value, "CanopyType must inherit from BaseCanopyParameters");
+    canopy_parameters_list.push_back(std::make_shared<CanopyType>(std::forward<Args>(args)...));
+}
+
+std::vector<std::shared_ptr<BaseCanopyParameters>> CanopyGenerator::getCanopyParametersList(){
+    std::vector<std::shared_ptr<BaseCanopyParameters>> params_list;
+    for (const auto& params : canopy_parameters_list) {
+        params_list.push_back(params);
+    }
+    return params_list;
+}
+
+void CanopyGenerator::loadXML( const char* filename, bool build ){
 
     if( printmessages ){
         std::cout << "Reading XML file: " << filename << "..." << std::flush;
     }
-
-    float nullvalue_f = 99999;
-    int nullvalue_i = 99999;
-    std::string nullvalue_s = "99999";
 
     //Check if file exists
     std::ifstream f(filename);
@@ -825,63 +1955,30 @@ void CanopyGenerator::loadXML( const char* filename ){
         for (pugi::xml_node s = cgen.child("HomogeneousCanopyParameters"); s; s = s.next_sibling(
                 "HomogeneousCanopyParameters")) {
 
-            HomogeneousCanopyParameters homogeneouscanopyparameters;
+            HomogeneousCanopyParameters homogeneouscanopyparameters(s);
+            storeCanopyParameters<HomogeneousCanopyParameters>(homogeneouscanopyparameters);
+            if (build)
+                buildCanopy(homogeneouscanopyparameters);
 
-            // ----- leaf size ------//
-            vec2 leaf_size = XMLloadvec2(s, "leaf_size");
-            if (leaf_size.x != nullvalue_f && leaf_size.y != nullvalue_f) {
-                homogeneouscanopyparameters.leaf_size = leaf_size;
-            }
+        }
 
-            // ----- leaf subdivisions ------//
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                homogeneouscanopyparameters.leaf_subdivisions = leaf_subdivisions;
-            }
+        //Spherical Canopy
+        for (pugi::xml_node s = cgen.child("SphericalCrownsCanopyParameters"); s; s = s.next_sibling("SphericalCrownsCanopyParameters")) {
 
-            // ----- leaf color ------//
-            RGBAcolor leaf_color = XMLloadrgba(s, "leaf_color");
-            if (leaf_color.a != 0) {
-                homogeneouscanopyparameters.leaf_color = make_RGBcolor(leaf_color.r,leaf_color.g,leaf_color.b);
-            }
+            SphericalCrownsCanopyParameters sphericalcrownscanopyparameters(s);
+            storeCanopyParameters<SphericalCrownsCanopyParameters>(sphericalcrownscanopyparameters);
+            if (build)
+                buildCanopy(sphericalcrownscanopyparameters);
 
-            // ----- leaf texture file ------//
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if (leaf_texture_file != nullvalue_s) {
-                homogeneouscanopyparameters.leaf_texture_file = leaf_texture_file;
-            }
+        }
 
-            // ----- leaf area index ------//
-            float LAI = XMLloadfloat(s, "leaf_area_index");
-            if (LAI != nullvalue_f) {
-                homogeneouscanopyparameters.leaf_area_index = LAI;
-            }
+        //Conical Canopy
+        for (pugi::xml_node s = cgen.child("ConicalCrownsCanopyParameters"); s; s = s.next_sibling("ConicalCrownsCanopyParameters")) {
 
-            // ----- canopy height ------//
-            float h = XMLloadfloat(s, "canopy_height");
-            if (h != nullvalue_f) {
-                homogeneouscanopyparameters.canopy_height = h;
-            }
-
-            // ----- canopy extent ------//
-            vec2 canopy_extent = XMLloadvec2(s, "canopy_extent");
-            if (canopy_extent.x != nullvalue_f && canopy_extent.y != nullvalue_f) {
-                homogeneouscanopyparameters.canopy_extent = canopy_extent;
-            }
-
-            // ----- canopy origin ------//
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                homogeneouscanopyparameters.canopy_origin = canopy_origin;
-            }
-
-            // ----- buffer ------//
-            std::string buffer = XMLloadstring(s, "buffer");
-            if ( buffer != nullvalue_s ) {
-                homogeneouscanopyparameters.buffer = buffer;
-            }
-
-            buildCanopy(homogeneouscanopyparameters);
+            ConicalCrownsCanopyParameters conicalcrownscanopyparameters(s);
+            storeCanopyParameters<ConicalCrownsCanopyParameters>(conicalcrownscanopyparameters);
+            if (build)
+                buildCanopy(conicalcrownscanopyparameters);
 
         }
 
@@ -889,124 +1986,10 @@ void CanopyGenerator::loadXML( const char* filename ){
         //VSP Grapevine Canopy
         for (pugi::xml_node s = cgen.child("VSPGrapevineParameters"); s; s = s.next_sibling("VSPGrapevineParameters")) {
 
-            VSPGrapevineParameters vspgrapevineparameters;
-
-            float leaf_width = XMLloadfloat(s, "leaf_width");
-            if (leaf_width != nullvalue_f) {
-                vspgrapevineparameters.leaf_width = leaf_width;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                vspgrapevineparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                vspgrapevineparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            std::string wood_texture_file = XMLloadstring(s, "wood_texture_file");
-            if ( wood_texture_file != nullvalue_s ) {
-                vspgrapevineparameters.wood_texture_file = wood_texture_file;
-            }
-
-            int wood_subdivisions = XMLloadint(s, "wood_subdivisions");
-            if ( wood_subdivisions != nullvalue_i) {
-                vspgrapevineparameters.wood_subdivisions = wood_subdivisions;
-            }
-
-            float h = XMLloadfloat(s, "trunk_height");
-            if (h != nullvalue_f) {
-                vspgrapevineparameters.trunk_height = h;
-            }
-
-            float r = XMLloadfloat(s, "trunk_radius");
-            if (r != nullvalue_f) {
-                vspgrapevineparameters.trunk_radius = r;
-            }
-
-            float ch = XMLloadfloat(s, "cordon_height");
-            if (ch != nullvalue_f) {
-                vspgrapevineparameters.cordon_height = ch;
-            }
-
-            float cr = XMLloadfloat(s, "cordon_radius");
-            if (cr != nullvalue_f) {
-                vspgrapevineparameters.cordon_radius = cr;
-            }
-
-            float sl = XMLloadfloat(s, "shoot_length");
-            if (sl != nullvalue_f) {
-                vspgrapevineparameters.shoot_length = sl;
-            }
-
-            float sr = XMLloadfloat(s, "shoot_radius");
-            if (sr != nullvalue_f) {
-                vspgrapevineparameters.shoot_radius = sr;
-            }
-
-            int spc = XMLloadint(s, "shoots_per_cordon");
-            if (spc != nullvalue_i) {
-                vspgrapevineparameters.shoots_per_cordon = uint(spc);
-            }
-
-            float lsf = XMLloadfloat(s, "leaf_spacing_fraction");
-            if (lsf != nullvalue_f) {
-                vspgrapevineparameters.leaf_spacing_fraction = lsf;
-            }
-
-            float gr = XMLloadfloat(s, "grape_radius");
-            if (gr != nullvalue_f) {
-                vspgrapevineparameters.grape_radius = gr;
-            }
-
-            float clr = XMLloadfloat(s, "cluster_radius");
-            if (clr != nullvalue_f) {
-                vspgrapevineparameters.cluster_radius = clr;
-            }
-
-            float clhm = XMLloadfloat(s, "cluster_height_max");
-            if (clhm != nullvalue_f) {
-                vspgrapevineparameters.cluster_height_max = clhm;
-            }
-
-            RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
-            if ( grape_color.a != 0 ) {
-                vspgrapevineparameters.grape_color = make_RGBcolor(grape_color.r,grape_color.g,grape_color.b);
-            }
-
-            int grape_subdivisions = XMLloadint(s, "grape_subdivisions");
-            if (grape_subdivisions != nullvalue_i) {
-                vspgrapevineparameters.grape_subdivisions = uint(grape_subdivisions);
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                vspgrapevineparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                vspgrapevineparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                vspgrapevineparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                vspgrapevineparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                vspgrapevineparameters.canopy_rotation = canopy_rotation;
-            }
-
-            buildCanopy(vspgrapevineparameters);
+            VSPGrapevineParameters vspgrapevineparameters(s);
+            storeCanopyParameters<VSPGrapevineParameters>(vspgrapevineparameters);
+            if (build)
+                buildCanopy(vspgrapevineparameters);
 
         }
 
@@ -1014,140 +1997,10 @@ void CanopyGenerator::loadXML( const char* filename ){
         for (pugi::xml_node s = cgen.child("SplitGrapevineParameters"); s; s = s.next_sibling(
                 "SplitGrapevineParameters")) {
 
-            SplitGrapevineParameters splitgrapevineparameters;
-
-            float leaf_width = XMLloadfloat(s, "leaf_width");
-            if (leaf_width != nullvalue_f) {
-                splitgrapevineparameters.leaf_width = leaf_width;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                splitgrapevineparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                splitgrapevineparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            std::string wood_texture_file = XMLloadstring(s, "wood_texture_file");
-            if ( wood_texture_file != nullvalue_s ) {
-                splitgrapevineparameters.wood_texture_file = wood_texture_file;
-            }
-
-            int wood_subdivisions = XMLloadint(s, "wood_subdivisions");
-            if (wood_subdivisions != nullvalue_i) {
-                splitgrapevineparameters.wood_subdivisions = wood_subdivisions;
-            }
-
-            float h = XMLloadfloat(s, "trunk_height");
-            if (h != nullvalue_f) {
-                splitgrapevineparameters.trunk_height = h;
-            }
-
-            float r = XMLloadfloat(s, "trunk_radius");
-            if (r != nullvalue_f) {
-                splitgrapevineparameters.trunk_radius = r;
-            }
-
-            float ch = XMLloadfloat(s, "cordon_height");
-            if (ch != nullvalue_f) {
-                splitgrapevineparameters.cordon_height = ch;
-            }
-
-            float cr = XMLloadfloat(s, "cordon_radius");
-            if (cr != nullvalue_f) {
-                splitgrapevineparameters.cordon_radius = cr;
-            }
-
-            float cs = XMLloadfloat(s, "cordon_spacing");
-            if (cs != nullvalue_f) {
-                splitgrapevineparameters.cordon_spacing = cs;
-            }
-
-            float sl = XMLloadfloat(s, "shoot_length");
-            if (sl != nullvalue_f) {
-                splitgrapevineparameters.shoot_length = sl;
-            }
-
-            float sr = XMLloadfloat(s, "shoot_radius");
-            if (sr != nullvalue_f) {
-                splitgrapevineparameters.shoot_radius = sr;
-            }
-
-            int spc = XMLloadint(s, "shoots_per_cordon");
-            if (spc != nullvalue_i) {
-                splitgrapevineparameters.shoots_per_cordon = uint(spc);
-            }
-
-            float sat = XMLloadfloat( s, "shoot_angle_tip" );
-            if( sat != nullvalue_f ){
-                splitgrapevineparameters.shoot_angle_tip = sat;
-            }
-
-            float sab = XMLloadfloat( s, "shoot_angle_base" );
-            if( sab != nullvalue_f ){
-                splitgrapevineparameters.shoot_angle_base = sab;
-            }
-
-            float lsf = XMLloadfloat(s, "leaf_spacing_fraction");
-            if (lsf != nullvalue_f) {
-                splitgrapevineparameters.leaf_spacing_fraction = lsf;
-            }
-
-            float gr = XMLloadfloat(s, "grape_radius");
-            if (gr != nullvalue_f) {
-                splitgrapevineparameters.grape_radius = gr;
-            }
-
-            float clr = XMLloadfloat(s, "cluster_radius");
-            if (clr != nullvalue_f) {
-                splitgrapevineparameters.cluster_radius = clr;
-            }
-
-            float clhm = XMLloadfloat(s, "cluster_height_max");
-            if (clhm != nullvalue_f) {
-                splitgrapevineparameters.cluster_height_max = clhm;
-            }
-
-            RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
-            if (grape_color.a!=0 ) {
-                splitgrapevineparameters.grape_color = make_RGBcolor(grape_color.r,grape_color.g,grape_color.b);
-            }
-
-            int grape_subdivisions = XMLloadint(s, "grape_subdivisions");
-            if (grape_subdivisions != nullvalue_i) {
-                splitgrapevineparameters.grape_subdivisions = uint(grape_subdivisions);
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                splitgrapevineparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                splitgrapevineparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                splitgrapevineparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                splitgrapevineparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                splitgrapevineparameters.canopy_rotation = canopy_rotation;
-            }
-
-
-            buildCanopy(splitgrapevineparameters);
+            SplitGrapevineParameters splitgrapevineparameters(s);
+            storeCanopyParameters<SplitGrapevineParameters>(splitgrapevineparameters);
+            if (build)
+                buildCanopy(splitgrapevineparameters);
 
         }
 
@@ -1156,131 +2009,10 @@ void CanopyGenerator::loadXML( const char* filename ){
         for (pugi::xml_node s = cgen.child("UnilateralGrapevineParameters"); s; s = s.next_sibling(
                 "UnilateralGrapevineParameters")) {
 
-            UnilateralGrapevineParameters unilateralgrapevineparameters;
-
-            float leaf_width = XMLloadfloat(s, "leaf_width");
-            if (leaf_width != nullvalue_f) {
-                unilateralgrapevineparameters.leaf_width = leaf_width;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                unilateralgrapevineparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                unilateralgrapevineparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            std::string wood_texture_file = XMLloadstring(s, "wood_texture_file");
-            if ( wood_texture_file != nullvalue_s ) {
-                unilateralgrapevineparameters.wood_texture_file = wood_texture_file;
-            }
-
-            int wood_subdivisions = XMLloadint(s, "wood_subdivisions");
-            if ( wood_subdivisions != nullvalue_i) {
-                unilateralgrapevineparameters.wood_subdivisions = wood_subdivisions;
-            }
-
-            float h = XMLloadfloat(s, "trunk_height");
-            if (h != nullvalue_f) {
-                unilateralgrapevineparameters.trunk_height = h;
-            }
-
-            float r = XMLloadfloat(s, "trunk_radius");
-            if (r != nullvalue_f) {
-                unilateralgrapevineparameters.trunk_radius = r;
-            }
-
-            float ch = XMLloadfloat(s, "cordon_height");
-            if (ch != nullvalue_f) {
-                unilateralgrapevineparameters.cordon_height = ch;
-            }
-
-            float cr = XMLloadfloat(s, "cordon_radius");
-            if (cr != nullvalue_f) {
-                unilateralgrapevineparameters.cordon_radius = cr;
-            }
-
-            float sl = XMLloadfloat(s, "shoot_length");
-            if (sl != nullvalue_f) {
-                unilateralgrapevineparameters.shoot_length = sl;
-            }
-
-            float sr = XMLloadfloat(s, "shoot_radius");
-            if (sr != nullvalue_f) {
-                unilateralgrapevineparameters.shoot_radius = sr;
-            }
-
-            int spc = XMLloadint(s, "shoots_per_cordon");
-            if (spc != nullvalue_i) {
-                unilateralgrapevineparameters.shoots_per_cordon = uint(spc);
-            }
-
-/*
-      float spa = XMLloadfloat( s, "shoots_tip_angle" );
-      if( spa != nullvalue_f ){
-	unilateralgrapevineparameters.shoots_tip_angle = uint(spa);
-      }*/
-
-            float lsf = XMLloadfloat(s, "leaf_spacing_fraction");
-            if (lsf != nullvalue_f) {
-                unilateralgrapevineparameters.leaf_spacing_fraction = lsf;
-            }
-
-            float gr = XMLloadfloat(s, "grape_radius");
-            if (gr != nullvalue_f) {
-                unilateralgrapevineparameters.grape_radius = gr;
-            }
-
-            float clr = XMLloadfloat(s, "cluster_radius");
-            if (clr != nullvalue_f) {
-                unilateralgrapevineparameters.cluster_radius = clr;
-            }
-
-            float clhm = XMLloadfloat(s, "cluster_height_max");
-            if (clhm != nullvalue_f) {
-                unilateralgrapevineparameters.cluster_height_max = clhm;
-            }
-
-            RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
-            if (grape_color.a!=0 ) {
-                unilateralgrapevineparameters.grape_color = make_RGBcolor(grape_color.r,grape_color.g,grape_color.b);
-            }
-
-            int grape_subdivisions = XMLloadint(s, "grape_subdivisions");
-            if (grape_subdivisions != nullvalue_i) {
-                unilateralgrapevineparameters.grape_subdivisions = uint(grape_subdivisions);
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                unilateralgrapevineparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                unilateralgrapevineparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                unilateralgrapevineparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                unilateralgrapevineparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                unilateralgrapevineparameters.canopy_rotation = canopy_rotation;
-            }
-
-
-            buildCanopy(unilateralgrapevineparameters);
+            UnilateralGrapevineParameters unilateralgrapevineparameters(s);
+            storeCanopyParameters<UnilateralGrapevineParameters>(unilateralgrapevineparameters);
+            if (build)
+                buildCanopy(unilateralgrapevineparameters);
 
         }
 
@@ -1289,797 +2021,71 @@ void CanopyGenerator::loadXML( const char* filename ){
         for (pugi::xml_node s = cgen.child("GobletGrapevineParameters"); s; s = s.next_sibling(
                 "GobletGrapevineParameters")) {
 
-            GobletGrapevineParameters gobletgrapevineparameters;
+            GobletGrapevineParameters gobletgrapevineparameters(s);
+            storeCanopyParameters<GobletGrapevineParameters>(gobletgrapevineparameters);
+            if (build)
+                buildCanopy(gobletgrapevineparameters);
 
-            float leaf_width = XMLloadfloat(s, "leaf_width");
-            if (leaf_width != nullvalue_f) {
-                gobletgrapevineparameters.leaf_width = leaf_width;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                gobletgrapevineparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                gobletgrapevineparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            std::string wood_texture_file = XMLloadstring(s, "wood_texture_file");
-            if ( wood_texture_file != nullvalue_s ) {
-                gobletgrapevineparameters.wood_texture_file = wood_texture_file;
-            }
-
-            int wood_subdivisions = XMLloadint(s, "wood_subdivisions");
-            if (wood_subdivisions != nullvalue_i) {
-                gobletgrapevineparameters.wood_subdivisions = wood_subdivisions;
-            }
-
-            float h = XMLloadfloat(s, "trunk_height");
-            if (h != nullvalue_f) {
-                gobletgrapevineparameters.trunk_height = h;
-            }
-
-            float r = XMLloadfloat(s, "trunk_radius");
-            if (r != nullvalue_f) {
-                gobletgrapevineparameters.trunk_radius = r;
-            }
-
-            float ch = XMLloadfloat(s, "cordon_height");
-            if (ch != nullvalue_f) {
-                gobletgrapevineparameters.cordon_height = ch;
-            }
-
-            float cr = XMLloadfloat(s, "cordon_radius");
-            if (cr != nullvalue_f) {
-                gobletgrapevineparameters.cordon_radius = cr;
-            }
-
-            float sl = XMLloadfloat(s, "shoot_length");
-            if (sl != nullvalue_f) {
-                gobletgrapevineparameters.shoot_length = sl;
-            }
-
-            float sr = XMLloadfloat(s, "shoot_radius");
-            if (sr != nullvalue_f) {
-                gobletgrapevineparameters.shoot_radius = sr;
-            }
-
-            int spc = XMLloadint(s, "shoots_per_cordon");
-            if (spc != nullvalue_i) {
-                gobletgrapevineparameters.shoots_per_cordon = uint(spc);
-            }
-/*
-      float spa = XMLloadfloat( s, "shoots_tip_angle" );
-      if( spa != nullvalue_f ){
-	gobletgrapevineparameters.shoots_tip_angle = uint(spa);
-      }*/
-
-            float lsf = XMLloadfloat(s, "leaf_spacing_fraction");
-            if (lsf != nullvalue_f) {
-                gobletgrapevineparameters.leaf_spacing_fraction = lsf;
-            }
-
-            float gr = XMLloadfloat(s, "grape_radius");
-            if (gr != nullvalue_f) {
-                gobletgrapevineparameters.grape_radius = gr;
-            }
-
-            float clr = XMLloadfloat(s, "cluster_radius");
-            if (clr != nullvalue_f) {
-                gobletgrapevineparameters.cluster_radius = clr;
-            }
-
-            float clhm = XMLloadfloat(s, "cluster_height_max");
-            if (clhm != nullvalue_f) {
-                gobletgrapevineparameters.cluster_height_max = clhm;
-            }
-
-            RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
-            if (grape_color.a != 0 ) {
-                gobletgrapevineparameters.grape_color = make_RGBcolor(grape_color.r,grape_color.g,grape_color.b);
-            }
-
-            int grape_subdivisions = XMLloadint(s, "grape_subdivisions");
-            if (grape_subdivisions != nullvalue_i) {
-                gobletgrapevineparameters.grape_subdivisions = uint(grape_subdivisions);
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                gobletgrapevineparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                gobletgrapevineparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                gobletgrapevineparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                gobletgrapevineparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                gobletgrapevineparameters.canopy_rotation = canopy_rotation;
-            }
+        }
 
 
-            buildCanopy(gobletgrapevineparameters);
+        //WhiteSpruceCanopyParameters Canopy
+        for (pugi::xml_node s = cgen.child("WhiteSpruceCanopyParameters"); s; s = s.next_sibling("WhiteSpruceCanopyParameters")) {
+
+            WhiteSpruceCanopyParameters whitesprucecanopyparameters(s);
+            storeCanopyParameters<WhiteSpruceCanopyParameters>(whitesprucecanopyparameters);
+            if (build)
+                buildCanopy(whitesprucecanopyparameters);
 
         }
 
         //StrawberryParameters Canopy
         for (pugi::xml_node s = cgen.child("StrawberryParameters"); s; s = s.next_sibling("StrawberryParameters")) {
 
-            StrawberryParameters strawberryparameters;
-
-            float leaf_length = XMLloadfloat(s, "leaf_length");
-            if (leaf_length != nullvalue_f) {
-                strawberryparameters.leaf_length = leaf_length;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                strawberryparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                strawberryparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            int stem_subdivisions = XMLloadint(s, "stem_subdivisions");
-            if (stem_subdivisions != nullvalue_i) {
-                strawberryparameters.stem_subdivisions = stem_subdivisions;
-            }
-
-            float stem_radius = XMLloadfloat(s, "stem_radius");
-            if (stem_radius != nullvalue_f) {
-                strawberryparameters.stem_radius = stem_radius;
-            }
-
-            float h = XMLloadfloat(s, "plant_height");
-            if (h != nullvalue_f) {
-                strawberryparameters.plant_height = h;
-            }
-
-            int r = XMLloadint(s, "stems_per_plant");
-            if (r != nullvalue_i) {
-                strawberryparameters.stems_per_plant = r;
-            }
-
-            float gr = XMLloadfloat(s, "fruit_radius");
-            if (gr != nullvalue_f) {
-                strawberryparameters.fruit_radius = gr;
-            }
-
-            float clr = XMLloadfloat(s, "clusters_per_stem");
-            if (clr != nullvalue_f) {
-                strawberryparameters.clusters_per_stem = clr;
-            }
-
-            int fruit_subdivisions = XMLloadint(s, "fruit_subdivisions");
-            if (fruit_subdivisions != nullvalue_i) {
-                strawberryparameters.fruit_subdivisions = uint(fruit_subdivisions);
-            }
-
-            std::string fruit_texture_file = XMLloadstring(s, "fruit_texture_file");
-            if ( fruit_texture_file != nullvalue_s ) {
-                strawberryparameters.fruit_texture_file = fruit_texture_file;
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                strawberryparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                strawberryparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                strawberryparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                strawberryparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                strawberryparameters.canopy_rotation = canopy_rotation;
-            }
-
-
-            buildCanopy(strawberryparameters);
+            StrawberryParameters strawberryparameters(s);
+            storeCanopyParameters<StrawberryParameters>(strawberryparameters);
+            if (build)
+                buildCanopy(strawberryparameters);
 
         }
 
         //TomatoParameters Canopy
         for (pugi::xml_node s = cgen.child("TomatoParameters"); s; s = s.next_sibling("TomatoParameters")) {
 
-            TomatoParameters tomatoparameters;
-
-            float leaf_length = XMLloadfloat(s, "leaf_length");
-            if (leaf_length != nullvalue_f) {
-                tomatoparameters.leaf_length = leaf_length;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                tomatoparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                tomatoparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            RGBAcolor shoot_color = XMLloadrgba(s, "shoot_color");
-            if (shoot_color.a != 0 ) {
-                tomatoparameters.shoot_color = make_RGBcolor(shoot_color.r,shoot_color.g,shoot_color.b);
-            }
-
-            int shoot_subdivisions = XMLloadint(s, "shoot_subdivisions");
-            if (shoot_subdivisions != nullvalue_i) {
-                tomatoparameters.shoot_subdivisions = shoot_subdivisions;
-            }
-
-            float h = XMLloadfloat(s, "plant_height");
-            if (h != nullvalue_f) {
-                tomatoparameters.plant_height = h;
-            }
-
-            float gr = XMLloadfloat(s, "fruit_radius");
-            if (gr != nullvalue_f) {
-                tomatoparameters.fruit_radius = gr;
-            }
-
-            RGBAcolor fruit_color = XMLloadrgba(s, "fruit_color");
-            if (fruit_color.a != 0 ) {
-                tomatoparameters.fruit_color = make_RGBcolor(fruit_color.r,fruit_color.g,fruit_color.b);
-            }
-
-
-            int fruit_subdivisions = XMLloadint(s, "fruit_subdivisions");
-            if (fruit_subdivisions != nullvalue_i) {
-                tomatoparameters.fruit_subdivisions = uint(fruit_subdivisions);
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                tomatoparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                tomatoparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                tomatoparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                tomatoparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                tomatoparameters.canopy_rotation = canopy_rotation;
-            }
-
-
-            buildCanopy(tomatoparameters);
+            TomatoParameters tomatoparameters(s);
+            storeCanopyParameters<TomatoParameters>(tomatoparameters);
+            if (build)
+                buildCanopy(tomatoparameters);
 
         }
 
         //WalnutCanopyParameters Canopy
         for (pugi::xml_node s = cgen.child("WalnutCanopyParameters"); s; s = s.next_sibling("WalnutCanopyParameters")) {
 
-            WalnutCanopyParameters walnutcanopyparameters;
-
-            float leaf_length = XMLloadfloat(s, "leaf_length");
-            if (leaf_length != nullvalue_f) {
-                walnutcanopyparameters.leaf_length = leaf_length;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                walnutcanopyparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                walnutcanopyparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            int wood_subdivisions = XMLloadint(s, "wood_subdivisions");
-            if (wood_subdivisions != nullvalue_i) {
-                walnutcanopyparameters.wood_subdivisions = wood_subdivisions;
-            }
-
-
-            float trunk_radius = XMLloadfloat(s, "trunk_radius");
-            if (trunk_radius != nullvalue_f) {
-                walnutcanopyparameters.trunk_radius = trunk_radius;
-            }
-
-            float trunk_height = XMLloadfloat(s, "trunk_height");
-            if (trunk_height != nullvalue_f) {
-                walnutcanopyparameters.trunk_height = trunk_height;
-            }
-
-            vec3 branch_length = XMLloadvec3(s, "branch_length");
-            if (branch_length.x != nullvalue_f && branch_length.y != nullvalue_f) {
-                walnutcanopyparameters.branch_length = branch_length;
-            }
-
-            std::string fruit_texture_file = XMLloadstring(s, "fruit_texture_file");
-            if ( fruit_texture_file != nullvalue_s ) {
-                walnutcanopyparameters.fruit_texture_file = fruit_texture_file;
-            }
-
-            int fruit_subdivisions = XMLloadint(s, "fruit_subdivisions");
-            if (fruit_subdivisions != nullvalue_i) {
-                walnutcanopyparameters.fruit_subdivisions = uint(fruit_subdivisions);
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                walnutcanopyparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                walnutcanopyparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                walnutcanopyparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                walnutcanopyparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                walnutcanopyparameters.canopy_rotation = canopy_rotation;
-            }
-
-
-            buildCanopy(walnutcanopyparameters);
+            WalnutCanopyParameters walnutcanopyparameters(s);
+            storeCanopyParameters<WalnutCanopyParameters>(walnutcanopyparameters);
+            if (build)
+                buildCanopy(walnutcanopyparameters);
 
         }
 
         //SorghumCanopyParameters Canopy
         for (pugi::xml_node s = cgen.child("SorghumCanopyParameters"); s; s = s.next_sibling("SorghumCanopyParameters")) {
 
-            SorghumCanopyParameters sorghumcanopyparameters;
-
-            int sorghum_stage = XMLloadint(s, "sorghum_stage");
-            if (sorghum_stage != nullvalue_i) {
-                sorghumcanopyparameters.sorghum_stage = sorghum_stage;
-            }
-            // STAGE 1
-            float s1_stem_length = XMLloadint(s, "s1_stem_length");
-            if (s1_stem_length != nullvalue_i) {
-                sorghumcanopyparameters.s1_stem_length = s1_stem_length;
-            }
-
-            float s1_stem_radius = XMLloadfloat(s, "s1_stem_radius");
-            if (s1_stem_radius != nullvalue_f) {
-                sorghumcanopyparameters.s1_stem_radius = s1_stem_radius;
-            }
-
-            int s1_stem_subdivisions = XMLloadint(s, "s1_stem_subdivisions");
-            if (s1_stem_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s1_stem_subdivisions = uint(s1_stem_subdivisions);
-            }
-
-            vec2 s1_leaf_size1 = XMLloadvec2(s, "s1_leaf_size1");
-            if (s1_leaf_size1.x != nullvalue_f && s1_leaf_size1.y != nullvalue_f) {
-                sorghumcanopyparameters.s1_leaf_size1 = s1_leaf_size1;
-            }
-
-            vec2 s1_leaf_size2 = XMLloadvec2(s, "s1_leaf_size2");
-            if (s1_leaf_size2.x != nullvalue_f && s1_leaf_size2.y != nullvalue_f) {
-                sorghumcanopyparameters.s1_leaf_size2 = s1_leaf_size2;
-            }
-
-            vec2 s1_leaf_size3 = XMLloadvec2(s, "s1_leaf_size3");
-            if (s1_leaf_size3.x != nullvalue_f && s1_leaf_size3.y != nullvalue_f) {
-                sorghumcanopyparameters.s1_leaf_size3 = s1_leaf_size3;
-            }
-
-            float s1_leaf1_angle = XMLloadfloat(s, "s1_leaf1_angle");
-            if (s1_leaf1_angle != nullvalue_f) {
-                sorghumcanopyparameters.s1_leaf1_angle = s1_leaf1_angle;
-            }
-
-            float s1_leaf2_angle = XMLloadfloat(s, "s1_leaf2_angle");
-            if (s1_leaf2_angle != nullvalue_f) {
-                sorghumcanopyparameters.s1_leaf2_angle = s1_leaf2_angle;
-            }
-
-            float s1_leaf3_angle = XMLloadfloat(s, "s1_leaf3_angle");
-            if (s1_leaf3_angle != nullvalue_f) {
-                sorghumcanopyparameters.s1_leaf3_angle = s1_leaf3_angle;
-            }
-
-            int2 s1_leaf_subdivisions = XMLloadint2(s, "s1_leaf_subdivisions");
-            if (s1_leaf_subdivisions.x != nullvalue_i && s1_leaf_subdivisions.y != nullvalue_i) {
-                sorghumcanopyparameters.s1_leaf_subdivisions = s1_leaf_subdivisions;
-            }
-
-            std::string s1_leaf_texture_file = XMLloadstring(s, "s1_leaf_texture_file");
-            if (s1_leaf_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s1_leaf_texture_file = s1_leaf_texture_file;
-            }
-            // STAGE 2
-            float s2_stem_length = XMLloadint(s, "s2_stem_length");
-            if (s2_stem_length != nullvalue_i) {
-                sorghumcanopyparameters.s2_stem_length = s2_stem_length;
-            }
-
-            float s2_stem_radius = XMLloadfloat(s, "s2_stem_radius");
-            if (s2_stem_radius != nullvalue_f) {
-                sorghumcanopyparameters.s2_stem_radius = s2_stem_radius;
-            }
-
-            int s2_stem_subdivisions = XMLloadint(s, "s2_stem_subdivisions");
-            if (s2_stem_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s2_stem_subdivisions = uint(s2_stem_subdivisions);
-            }
-
-            vec2 s2_leaf_size1 = XMLloadvec2(s, "s2_leaf_size1");
-            if (s2_leaf_size1.x != nullvalue_f && s2_leaf_size1.y != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf_size1 = s2_leaf_size1;
-            }
-
-            vec2 s2_leaf_size2 = XMLloadvec2(s, "s2_leaf_size2");
-            if (s2_leaf_size2.x != nullvalue_f && s2_leaf_size2.y != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf_size2 = s2_leaf_size2;
-            }
-
-            vec2 s2_leaf_size3 = XMLloadvec2(s, "s2_leaf_size3");
-            if (s2_leaf_size3.x != nullvalue_f && s2_leaf_size3.y != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf_size3 = s2_leaf_size3;
-            }
-
-            vec2 s2_leaf_size4 = XMLloadvec2(s, "s2_leaf_size4");
-            if (s2_leaf_size4.x != nullvalue_f && s2_leaf_size4.y != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf_size4 = s2_leaf_size4;
-            }
-
-            vec2 s2_leaf_size5 = XMLloadvec2(s, "s2_leaf_size5");
-            if (s2_leaf_size5.x != nullvalue_f && s2_leaf_size5.y != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf_size5 = s2_leaf_size5;
-            }
-
-            float s2_leaf1_angle = XMLloadfloat(s, "s2_leaf1_angle");
-            if (s2_leaf1_angle != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf1_angle = s2_leaf1_angle;
-            }
-
-            float s2_leaf2_angle = XMLloadfloat(s, "s2_leaf2_angle");
-            if (s2_leaf2_angle != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf2_angle = s2_leaf2_angle;
-            }
-
-            float s2_leaf3_angle = XMLloadfloat(s, "s2_leaf3_angle");
-            if (s2_leaf3_angle != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf3_angle = s2_leaf3_angle;
-            }
-
-            float s2_leaf4_angle = XMLloadfloat(s, "s2_leaf4_angle");
-            if (s2_leaf4_angle != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf4_angle = s2_leaf4_angle;
-            }
-
-            float s2_leaf5_angle = XMLloadfloat(s, "s2_leaf5_angle");
-            if (s2_leaf3_angle != nullvalue_f) {
-                sorghumcanopyparameters.s2_leaf5_angle = s2_leaf5_angle;
-            }
-
-            int2 s2_leaf_subdivisions = XMLloadint2(s, "s2_leaf_subdivisions");
-            if (s2_leaf_subdivisions.x != nullvalue_i && s2_leaf_subdivisions.y != nullvalue_i) {
-                sorghumcanopyparameters.s2_leaf_subdivisions = s2_leaf_subdivisions;
-            }
-
-            std::string s2_leaf_texture_file = XMLloadstring(s, "s2_leaf_texture_file");
-            if (s2_leaf_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s2_leaf_texture_file = s2_leaf_texture_file;
-            }
-            // STAGE 3
-            float s3_stem_length = XMLloadint(s, "s3_stem_length");
-            if (s3_stem_length != nullvalue_i) {
-                sorghumcanopyparameters.s3_stem_length = s3_stem_length;
-            }
-
-            float s3_stem_radius = XMLloadfloat(s, "s3_stem_radius");
-            if (s3_stem_radius != nullvalue_f) {
-                sorghumcanopyparameters.s3_stem_radius = s3_stem_radius;
-            }
-
-            int s3_stem_subdivisions = XMLloadint(s, "s3_stem_subdivisions");
-            if (s3_stem_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s3_stem_subdivisions = uint(s3_stem_subdivisions);
-            }
-
-            vec2 s3_leaf_size = XMLloadvec2(s, "s3_leaf_size");
-            if (s3_leaf_size.x != nullvalue_f && s3_leaf_size.y != nullvalue_f) {
-                sorghumcanopyparameters.s3_leaf_size = s3_leaf_size;
-            }
-
-            int2 s3_leaf_subdivisions = XMLloadint2(s, "s3_leaf_subdivisions");
-            if (s3_leaf_subdivisions.x != nullvalue_i && s3_leaf_subdivisions.y != nullvalue_i) {
-                sorghumcanopyparameters.s3_leaf_subdivisions = s3_leaf_subdivisions;
-            }
-
-            int s3_number_of_leaves = XMLloadint(s, "s3_number_of_leaves");
-            if (s3_number_of_leaves != nullvalue_i) {
-                sorghumcanopyparameters.s3_number_of_leaves = s3_number_of_leaves;
-            }
-
-            float s3_mean_leaf_angle = XMLloadfloat(s, "s3_mean_leaf_angle");
-            if (s3_mean_leaf_angle != nullvalue_f) {
-                sorghumcanopyparameters.s3_mean_leaf_angle = s3_mean_leaf_angle;
-            }
-
-            std::string s3_leaf_texture_file = XMLloadstring(s, "s3_leaf_texture_file");
-            if (s3_leaf_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s3_leaf_texture_file = s3_leaf_texture_file;
-            }
-
-            // STAGE 4
-            float s4_stem_length = XMLloadint(s, "s4_stem_length");
-            if (s4_stem_length != nullvalue_i) {
-                sorghumcanopyparameters.s4_stem_length = s4_stem_length;
-            }
-
-            float s4_stem_radius = XMLloadfloat(s, "s4_stem_radius");
-            if (s4_stem_radius != nullvalue_f) {
-                sorghumcanopyparameters.s4_stem_radius = s4_stem_radius;
-            }
-
-            int s4_stem_subdivisions = XMLloadint(s, "s4_stem_subdivisions");
-            if (s4_stem_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s4_stem_subdivisions = uint(s4_stem_subdivisions);
-            }
-
-            vec2 s4_panicle_size = XMLloadvec2(s, "s4_panicle_size");
-            if (s4_panicle_size.x != nullvalue_f && s4_panicle_size.y != nullvalue_f) {
-                sorghumcanopyparameters.s4_panicle_size = s4_panicle_size;
-            }
-
-            int s4_panicle_subdivisions = XMLloadint(s, "s4_panicle_subdivisions");
-            if (s4_panicle_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s4_panicle_subdivisions = uint(s4_panicle_subdivisions);
-            }
-
-            std::string s4_seed_texture_file = XMLloadstring(s, "s4_seed_texture_file");
-            if (s4_seed_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s4_seed_texture_file = s4_seed_texture_file;
-            }
-
-            vec2 s4_leaf_size = XMLloadvec2(s, "s4_leaf_size");
-            if (s4_leaf_size.x != nullvalue_f && s4_leaf_size.y != nullvalue_f) {
-                sorghumcanopyparameters.s4_leaf_size = s4_leaf_size;
-            }
-
-            int2 s4_leaf_subdivisions = XMLloadint2(s, "s4_leaf_subdivisions");
-            if (s4_leaf_subdivisions.x != nullvalue_i && s4_leaf_subdivisions.y != nullvalue_i) {
-                sorghumcanopyparameters.s4_leaf_subdivisions = s4_leaf_subdivisions;
-            }
-
-            int s4_number_of_leaves = XMLloadint(s, "s4_number_of_leaves");
-            if (s4_number_of_leaves != nullvalue_i) {
-                sorghumcanopyparameters.s4_number_of_leaves = s4_number_of_leaves;
-            }
-
-            float s4_mean_leaf_angle = XMLloadfloat(s, "s4_mean_leaf_angle");
-            if (s4_mean_leaf_angle != nullvalue_f) {
-                sorghumcanopyparameters.s4_mean_leaf_angle = s4_mean_leaf_angle;
-            }
-
-            std::string s4_leaf_texture_file = XMLloadstring(s, "s4_leaf_texture_file");
-            if (s4_leaf_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s4_leaf_texture_file = s4_leaf_texture_file;
-            }
-
-            // STAGE 5
-            float s5_stem_length = XMLloadint(s, "s5_stem_length");
-            if (s5_stem_length != nullvalue_i) {
-                sorghumcanopyparameters.s5_stem_length = s5_stem_length;
-            }
-
-            float s5_stem_radius = XMLloadfloat(s, "s5_stem_radius");
-            if (s5_stem_radius != nullvalue_f) {
-                sorghumcanopyparameters.s5_stem_radius = s5_stem_radius;
-            }
-
-            float s5_stem_bend = XMLloadfloat(s, "s5_stem_bend");
-            if (s5_stem_bend != nullvalue_f) {
-                sorghumcanopyparameters.s5_stem_bend = s5_stem_bend;
-            }
-
-            int s5_stem_subdivisions = XMLloadint(s, "s5_stem_subdivisions");
-            if (s5_stem_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s5_stem_subdivisions = uint(s5_stem_subdivisions);
-            }
-
-            vec2 s5_panicle_size = XMLloadvec2(s, "s5_panicle_size");
-            if (s5_panicle_size.x != nullvalue_f && s5_panicle_size.y != nullvalue_f) {
-                sorghumcanopyparameters.s5_panicle_size = s5_panicle_size;
-            }
-
-            int s5_panicle_subdivisions = XMLloadint(s, "s5_panicle_subdivisions");
-            if (s5_panicle_subdivisions != nullvalue_f) {
-                sorghumcanopyparameters.s5_panicle_subdivisions = uint(s5_panicle_subdivisions);
-            }
-
-            std::string s5_seed_texture_file = XMLloadstring(s, "s5_seed_texture_file");
-            if (s5_seed_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s5_seed_texture_file = s5_seed_texture_file;
-            }
-
-            vec2 s5_leaf_size = XMLloadvec2(s, "s5_leaf_size");
-            if (s5_leaf_size.x != nullvalue_f && s5_leaf_size.y != nullvalue_f) {
-                sorghumcanopyparameters.s5_leaf_size = s5_leaf_size;
-            }
-
-            int2 s5_leaf_subdivisions = XMLloadint2(s, "s5_leaf_subdivisions");
-            if (s5_leaf_subdivisions.x != nullvalue_i && s5_leaf_subdivisions.y != nullvalue_i) {
-                sorghumcanopyparameters.s5_leaf_subdivisions = s5_leaf_subdivisions;
-            }
-
-            int s5_number_of_leaves = XMLloadint(s, "s5_number_of_leaves");
-            if (s5_number_of_leaves != nullvalue_i) {
-                sorghumcanopyparameters.s5_number_of_leaves = s5_number_of_leaves;
-            }
-
-            float s5_mean_leaf_angle = XMLloadfloat(s, "s5_mean_leaf_angle");
-            if (s5_mean_leaf_angle != nullvalue_f) {
-                sorghumcanopyparameters.s5_mean_leaf_angle = s5_mean_leaf_angle;
-            }
-
-            std::string s5_leaf_texture_file = XMLloadstring(s, "s5_leaf_texture_file");
-            if (s5_leaf_texture_file.compare(nullvalue_s) != 0) {
-                sorghumcanopyparameters.s5_leaf_texture_file = s5_leaf_texture_file;
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                sorghumcanopyparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                sorghumcanopyparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                sorghumcanopyparameters.plant_count = plant_count;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                sorghumcanopyparameters.canopy_origin = canopy_origin;
-            }
-
-            buildCanopy(sorghumcanopyparameters);
+            SorghumCanopyParameters sorghumcanopyparameters(s);
+            storeCanopyParameters<SorghumCanopyParameters>(sorghumcanopyparameters);
+            if (build)
+                buildCanopy(sorghumcanopyparameters);
 
         }
 
         //BeanParameters Canopy
         for (pugi::xml_node s = cgen.child("BeanParameters"); s; s = s.next_sibling("BeanParameters")) {
 
-            BeanParameters beanparameters;
-
-            float leaf_length = XMLloadfloat(s, "leaf_length");
-            if (leaf_length != nullvalue_f) {
-                beanparameters.leaf_length = leaf_length;
-            }
-
-            int2 leaf_subdivisions = XMLloadint2(s, "leaf_subdivisions");
-            if (leaf_subdivisions.x != nullvalue_i && leaf_subdivisions.y != nullvalue_i) {
-                beanparameters.leaf_subdivisions = leaf_subdivisions;
-            }
-
-            std::string leaf_texture_file = XMLloadstring(s, "leaf_texture_file");
-            if ( leaf_texture_file != nullvalue_s ) {
-                beanparameters.leaf_texture_file = leaf_texture_file;
-            }
-
-            int shoot_subdivisions = XMLloadint(s, "shoot_subdivisions");
-            if (shoot_subdivisions != nullvalue_i) {
-                beanparameters.shoot_subdivisions = shoot_subdivisions;
-            }
-
-            float stem_radius = XMLloadfloat(s, "stem_radius");
-            if (stem_radius != nullvalue_f) {
-                beanparameters.stem_radius = stem_radius;
-            }
-
-            RGBAcolor shoot_color = XMLloadrgba(s, "shoot_color");
-            if( shoot_color.a != 0 ){
-                beanparameters.shoot_color = make_RGBcolor(shoot_color.r,shoot_color.g,shoot_color.b);
-            }
-
-            float stem_length = XMLloadfloat(s, "stem_length");
-            if (stem_length != nullvalue_f ) {
-                beanparameters.stem_length = stem_length;
-            }
-
-            float leaflet_length = XMLloadfloat(s, "leaflet_length");
-            if (leaflet_length != nullvalue_f ) {
-                beanparameters.leaflet_length = leaflet_length;
-            }
-
-            float pod_length = XMLloadfloat(s, "pod_length");
-            if (pod_length != nullvalue_f ) {
-                beanparameters.pod_length = pod_length;
-            }
-
-            RGBAcolor pod_color = XMLloadrgba(s, "pod_color");
-            if( pod_color.a != 0 ){
-                beanparameters.pod_color = make_RGBcolor(pod_color.r,pod_color.g,pod_color.b);
-            }
-
-            int pod_subdivisions = XMLloadint(s, "pod_subdivisions");
-            if (pod_subdivisions != nullvalue_i ) {
-                beanparameters.pod_subdivisions = pod_subdivisions;
-            }
-
-            float plant_spacing = XMLloadfloat(s, "plant_spacing");
-            if (plant_spacing != nullvalue_f) {
-                beanparameters.plant_spacing = plant_spacing;
-            }
-
-            float row_spacing = XMLloadfloat(s, "row_spacing");
-            if (row_spacing != nullvalue_f) {
-                beanparameters.row_spacing = row_spacing;
-            }
-
-            int2 plant_count = XMLloadint2(s, "plant_count");
-            if (plant_count.x != nullvalue_i && plant_count.y != nullvalue_i) {
-                beanparameters.plant_count = plant_count;
-            }
-
-            float germination_probability = XMLloadfloat(s, "germination_probability");
-            if (germination_probability != nullvalue_f) {
-                beanparameters.germination_probability = germination_probability;
-            }
-
-            vec3 canopy_origin = XMLloadvec3(s, "canopy_origin");
-            if (canopy_origin.x != nullvalue_f && canopy_origin.y != nullvalue_f) {
-                beanparameters.canopy_origin = canopy_origin;
-            }
-
-            float canopy_rotation = XMLloadfloat(s, "canopy_rotation");
-            if (canopy_rotation != nullvalue_f) {
-                beanparameters.canopy_rotation = canopy_rotation;
-            }
-
-            buildCanopy(beanparameters);
+            BeanParameters beanparameters(s);
+            storeCanopyParameters<BeanParameters>(beanparameters);
+            if (build)
+                buildCanopy(beanparameters);
 
         }
 
@@ -2125,7 +2131,8 @@ void CanopyGenerator::loadXML( const char* filename ){
                 rotation = 0;
             }
 
-            buildGround(origin, extent, texture_subtiles, texture_subpatches, texturefile.c_str(), rotation);
+            if (build)
+                buildGround(origin, extent, texture_subtiles, texture_subpatches, texturefile.c_str(), rotation);
 
         }
 
@@ -2171,6 +2178,12 @@ void CanopyGenerator::buildGround(const vec3 &ground_origin, const vec2 &ground_
         std::cout << "Ground consists of " << UUID_ground.size() << " total primitives." << std::endl;
     }
 
+}
+
+void CanopyGenerator::buildCanopies(){
+    for (const auto& canopy_parameters : canopy_parameters_list) {
+        canopy_parameters->buildCanopy(*this);
+    }
 }
 
 void CanopyGenerator::buildCanopy(const HomogeneousCanopyParameters &params ){
@@ -3005,6 +3018,19 @@ void CanopyGenerator::disableMessages(){
 
 void CanopyGenerator::enableMessages(){
     printmessages=true;
+}
+
+void CanopyGenerator::buildIndividualPlants(helios::vec3 position){
+    for (const auto& params : canopy_parameters_list) {
+        params->buildPlant(*this, position);
+    }
+}
+
+void CanopyGenerator::buildIndividualPlants(){
+    for (const auto& params : canopy_parameters_list) {
+        vec3 position = params->canopy_origin;
+        params->buildPlant(*this, position);
+    }
 }
 
 helios::vec3 interpolateTube(const std::vector<vec3> &P, float frac ){

--- a/plugins/canopygenerator/src/CanopyGenerator.cpp
+++ b/plugins/canopygenerator/src/CanopyGenerator.cpp
@@ -378,6 +378,9 @@ BaseGrapeVineParameters::BaseGrapeVineParameters() : BaseCanopyParameters(){
 
     row_spacing_spread = 0;
 
+    dead_probability = 0;
+    missing_plant_probability = 0;
+
 }
 
 BaseGrapeVineParameters::BaseGrapeVineParameters(const pugi::xml_node canopy_node) : BaseGrapeVineParameters(){
@@ -570,6 +573,22 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
     int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
     if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
         plant_count = new_plant_count;
+    }
+
+    float new_dead_probability = XMLloadfloat(canopy_node, "dead_probability");
+    if (new_dead_probability != nullvalue_f) {
+        if (new_dead_probability < 0 || new_dead_probability > 1)
+            std::cout << "BaseGrapeVineParameters::readParametersFromXML: dead_probability value must be between 0 and 1" << std::endl;
+        else
+            dead_probability = new_dead_probability;
+    }
+
+    float new_missing_plant_probability = XMLloadfloat(canopy_node, "missing_plant_probability");
+    if (new_missing_plant_probability != nullvalue_f) {
+        if (new_missing_plant_probability < 0 || new_missing_plant_probability > 1)
+            std::cout << "BaseGrapeVineParameters::readParametersFromXML: missing_plant_probability value must be between 0 and 1" << std::endl;
+        else
+            missing_plant_probability = new_missing_plant_probability;
     }
 
     float new_canopy_rotation_spread = XMLloadfloat(canopy_node, "canopy_rotation_spread");
@@ -2595,6 +2614,14 @@ void CanopyGenerator::buildCanopy(const VSPGrapevineParameters &params ){
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
 
+            if( params.missing_plant_probability > 0 ){
+                float random_draw = context->randu();
+                if( random_draw <= params.missing_plant_probability ){
+                    // Don't add the plant
+                    continue;
+                }
+            }
+
             float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
             float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
             vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*row_spacing, 0 );
@@ -2628,6 +2655,14 @@ void CanopyGenerator::buildCanopy(const SplitGrapevineParameters &params ){
     uint prim_count = 0;
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
+
+            if( params.missing_plant_probability > 0 ){
+                float random_draw = context->randu();
+                if( random_draw <= params.missing_plant_probability ){
+                    // Don't add the plant
+                    continue;
+                }
+            }
 
             float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
             float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
@@ -2663,6 +2698,14 @@ void CanopyGenerator::buildCanopy(const UnilateralGrapevineParameters &params ){
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
 
+            if( params.missing_plant_probability > 0 ){
+                float random_draw = context->randu();
+                if( random_draw <= params.missing_plant_probability ){
+                    // Don't add the plant
+                    continue;
+                }
+            }
+
             float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
             float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
             vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*row_spacing, 0 );
@@ -2696,6 +2739,14 @@ void CanopyGenerator::buildCanopy(const GobletGrapevineParameters &params ){
     uint prim_count = 0;
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
+
+            if( params.missing_plant_probability > 0 ){
+                float random_draw = context->randu();
+                if( random_draw <= params.missing_plant_probability ){
+                    // Don't add the plant
+                    continue;
+                }
+            }
 
             float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
             float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);

--- a/plugins/canopygenerator/src/CanopyGenerator.cpp
+++ b/plugins/canopygenerator/src/CanopyGenerator.cpp
@@ -966,6 +966,11 @@ void CanopyGenerator::loadXML( const char* filename ){
                 vspgrapevineparameters.cluster_radius = clr;
             }
 
+            float clhm = XMLloadfloat(s, "cluster_height_max");
+            if (clhm != nullvalue_f) {
+                vspgrapevineparameters.cluster_height_max = clhm;
+            }
+
             RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
             if ( grape_color.a != 0 ) {
                 vspgrapevineparameters.grape_color = make_RGBcolor(grape_color.r,grape_color.g,grape_color.b);
@@ -1076,11 +1081,16 @@ void CanopyGenerator::loadXML( const char* filename ){
                 splitgrapevineparameters.shoots_per_cordon = uint(spc);
             }
 
-/*
-      float spa = XMLloadfloat( s, "shoots_tip_angle" );
-      if( spa != nullvalue_f ){
-	splitgrapevineparameters.shoots_tip_angle = uint(spa);
-*/
+            float sat = XMLloadfloat( s, "shoot_angle_tip" );
+            if( sat != nullvalue_f ){
+                splitgrapevineparameters.shoot_angle_tip = sat;
+            }
+
+            float sab = XMLloadfloat( s, "shoot_angle_base" );
+            if( sab != nullvalue_f ){
+                splitgrapevineparameters.shoot_angle_base = sab;
+            }
+
             float lsf = XMLloadfloat(s, "leaf_spacing_fraction");
             if (lsf != nullvalue_f) {
                 splitgrapevineparameters.leaf_spacing_fraction = lsf;
@@ -1094,6 +1104,11 @@ void CanopyGenerator::loadXML( const char* filename ){
             float clr = XMLloadfloat(s, "cluster_radius");
             if (clr != nullvalue_f) {
                 splitgrapevineparameters.cluster_radius = clr;
+            }
+
+            float clhm = XMLloadfloat(s, "cluster_height_max");
+            if (clhm != nullvalue_f) {
+                splitgrapevineparameters.cluster_height_max = clhm;
             }
 
             RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
@@ -1224,6 +1239,11 @@ void CanopyGenerator::loadXML( const char* filename ){
                 unilateralgrapevineparameters.cluster_radius = clr;
             }
 
+            float clhm = XMLloadfloat(s, "cluster_height_max");
+            if (clhm != nullvalue_f) {
+                unilateralgrapevineparameters.cluster_height_max = clhm;
+            }
+
             RGBAcolor grape_color = XMLloadrgba(s, "grape_color");
             if (grape_color.a!=0 ) {
                 unilateralgrapevineparameters.grape_color = make_RGBcolor(grape_color.r,grape_color.g,grape_color.b);
@@ -1349,6 +1369,11 @@ void CanopyGenerator::loadXML( const char* filename ){
             float clr = XMLloadfloat(s, "cluster_radius");
             if (clr != nullvalue_f) {
                 gobletgrapevineparameters.cluster_radius = clr;
+            }
+
+            float clhm = XMLloadfloat(s, "cluster_height_max");
+            if (clhm != nullvalue_f) {
+                gobletgrapevineparameters.cluster_height_max = clhm;
             }
 
             RGBAcolor grape_color = XMLloadrgba(s, "grape_color");

--- a/plugins/canopygenerator/src/CanopyGenerator.cpp
+++ b/plugins/canopygenerator/src/CanopyGenerator.cpp
@@ -354,6 +354,7 @@ BaseGrapeVineParameters::BaseGrapeVineParameters() : BaseCanopyParameters(){
 
     trunk_height_spread = 0;
 
+    cordon_length_spread = 0;
     cordon_height_spread = 0;
     cordon_radius_spread = 0;
 
@@ -443,6 +444,16 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
     float new_trunk_radius_spread = XMLloadfloat(canopy_node, "trunk_radius_spread");
     if (new_trunk_radius_spread != nullvalue_f) {
         trunk_radius_spread = new_trunk_radius_spread;
+    }
+
+    float new_cordon_length = XMLloadfloat(canopy_node, "cordon_length");
+    if (new_cordon_length != nullvalue_f) {
+        cordon_length = new_cordon_length;
+    }
+
+    float new_cordon_length_spread = XMLloadfloat(canopy_node, "cordon_length_spread");
+    if (new_cordon_length_spread != nullvalue_f) {
+        cordon_length_spread = new_cordon_length_spread;
     }
 
     float ch = XMLloadfloat(canopy_node, "cordon_height");
@@ -633,6 +644,8 @@ VSPGrapevineParameters::VSPGrapevineParameters() : BaseGrapeVineParameters(){
 
     plant_spacing = 2;
 
+    cordon_length = 0.5 * plant_spacing;
+
     row_spacing = 2;
 
 }
@@ -689,6 +702,8 @@ SplitGrapevineParameters::SplitGrapevineParameters() : BaseGrapeVineParameters()
     grape_subdivisions = 8;
 
     plant_spacing = 2;
+
+    cordon_length = 0.5 * plant_spacing;
 
     row_spacing = 4;
 
@@ -752,6 +767,8 @@ UnilateralGrapevineParameters::UnilateralGrapevineParameters() : BaseGrapeVinePa
     grape_subdivisions = 8;
 
     plant_spacing = 1.5;
+
+    cordon_length = 0.5 * plant_spacing;
 
     row_spacing = 2;
 

--- a/plugins/canopygenerator/src/CanopyGenerator.cpp
+++ b/plugins/canopygenerator/src/CanopyGenerator.cpp
@@ -343,14 +343,40 @@ BaseGrapeVineParameters::BaseGrapeVineParameters() : BaseCanopyParameters(){
     wood_texture_file = "plugins/canopygenerator/textures/wood.jpg";
 
     leaf_width = 0.18;
+    leaf_width_spread = 0;
 
     leaf_subdivisions = make_int2(1,1);
 
+    leaf_spacing_fraction_spread = 0;
+
     wood_subdivisions = 10;
+    wood_subdivisions_spread = 0;
+
+    trunk_height_spread = 0;
+
+    cordon_height_spread = 0;
+    cordon_radius_spread = 0;
+
+    shoot_length_spread = 0;
+    shoot_radius_spread = 0;
+    shoots_per_cordon_spread = 0;
 
     grape_color = make_RGBcolor(0.18,0.2,0.25);
 
+    grape_radius_spread = 0;
+
+    cluster_radius_spread = 0;
+    cluster_height_max_spread = 0;
+
+    grape_subdivisions_spread = 0;
+
     plant_count = make_int2(3,3);
+
+    canopy_rotation_spread = 0;
+
+    plant_spacing_spread = 0;
+
+    row_spacing_spread = 0;
 
 }
 
@@ -364,6 +390,11 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
     float new_leaf_width = XMLloadfloat(canopy_node, "leaf_width");
     if (new_leaf_width != nullvalue_f) {
         leaf_width = new_leaf_width;
+    }
+
+    float new_leaf_width_spread = XMLloadfloat(canopy_node, "leaf_width_spread");
+    if (new_leaf_width_spread != nullvalue_f) {
+        leaf_width_spread = new_leaf_width_spread;
     }
 
     int2 new_leaf_subdivisions = XMLloadint2(canopy_node, "leaf_subdivisions");
@@ -386,9 +417,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         wood_subdivisions = new_wood_subdivisions;
     }
 
+    int new_wood_subdivisions_spread = XMLloadint(canopy_node, "wood_subdivisions_spread");
+    if ( new_wood_subdivisions_spread != nullvalue_i) {
+        wood_subdivisions_spread = new_wood_subdivisions_spread;
+    }
+
     float h = XMLloadfloat(canopy_node, "trunk_height");
     if (h != nullvalue_f) {
         trunk_height = h;
+    }
+
+    float new_trunk_height_spread = XMLloadfloat(canopy_node, "trunk_height_spread");
+    if (new_trunk_height_spread != nullvalue_f) {
+        trunk_height_spread = new_trunk_height_spread;
     }
 
     float r = XMLloadfloat(canopy_node, "trunk_radius");
@@ -396,9 +437,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         trunk_radius = r;
     }
 
+    float new_trunk_radius_spread = XMLloadfloat(canopy_node, "trunk_radius_spread");
+    if (new_trunk_radius_spread != nullvalue_f) {
+        trunk_radius_spread = new_trunk_radius_spread;
+    }
+
     float ch = XMLloadfloat(canopy_node, "cordon_height");
     if (ch != nullvalue_f) {
         cordon_height = ch;
+    }
+
+    float new_cordon_height_spread = XMLloadfloat(canopy_node, "cordon_height_spread");
+    if (new_cordon_height_spread != nullvalue_f) {
+        cordon_height_spread = new_cordon_height_spread;
     }
 
     float cr = XMLloadfloat(canopy_node, "cordon_radius");
@@ -406,9 +457,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         cordon_radius = cr;
     }
 
+    float new_cordon_radius_spread = XMLloadfloat(canopy_node, "cordon_radius_spread");
+    if (new_cordon_radius_spread != nullvalue_f) {
+        cordon_radius_spread = new_cordon_radius_spread;
+    }
+
     float sl = XMLloadfloat(canopy_node, "shoot_length");
     if (sl != nullvalue_f) {
         shoot_length = sl;
+    }
+
+    float new_shoot_length_spread = XMLloadfloat(canopy_node, "shoot_length_spread");
+    if (new_shoot_length_spread != nullvalue_f) {
+        shoot_length_spread = new_shoot_length_spread;
     }
 
     float sr = XMLloadfloat(canopy_node, "shoot_radius");
@@ -416,9 +477,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         shoot_radius = sr;
     }
 
+    float new_shoot_radius_spread = XMLloadfloat(canopy_node, "shoot_radius_spread");
+    if (new_shoot_radius_spread != nullvalue_f) {
+        shoot_radius_spread = new_shoot_radius_spread;
+    }
+
     int spc = XMLloadint(canopy_node, "shoots_per_cordon");
     if (spc != nullvalue_i) {
         shoots_per_cordon = uint(spc);
+    }
+
+    int new_shoots_per_cordon_spread = XMLloadint(canopy_node, "shoots_per_cordon_spread");
+    if (new_shoots_per_cordon_spread != nullvalue_i) {
+        shoots_per_cordon_spread = uint(new_shoots_per_cordon_spread);
     }
 
     float lsf = XMLloadfloat(canopy_node, "leaf_spacing_fraction");
@@ -426,9 +497,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         leaf_spacing_fraction = lsf;
     }
 
+    float new_leaf_spacing_fraction_spread = XMLloadfloat(canopy_node, "leaf_spacing_fraction_spread");
+    if (new_leaf_spacing_fraction_spread != nullvalue_f) {
+        leaf_spacing_fraction_spread = new_leaf_spacing_fraction_spread;
+    }
+
     float gr = XMLloadfloat(canopy_node, "grape_radius");
     if (gr != nullvalue_f) {
         grape_radius = gr;
+    }
+
+    float new_grape_radius_spread = XMLloadfloat(canopy_node, "grape_radius_spread");
+    if (new_grape_radius_spread != nullvalue_f) {
+        grape_radius_spread = new_grape_radius_spread;
     }
 
     float clr = XMLloadfloat(canopy_node, "cluster_radius");
@@ -436,9 +517,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         cluster_radius = clr;
     }
 
+    float new_cluster_radius_spread = XMLloadfloat(canopy_node, "cluster_radius_spread");
+    if (new_cluster_radius_spread != nullvalue_f) {
+        cluster_radius_spread = new_cluster_radius_spread;
+    }
+
     float clhm = XMLloadfloat(canopy_node, "cluster_height_max");
     if (clhm != nullvalue_f) {
         cluster_height_max = clhm;
+    }
+
+    float new_cluster_height_max_spread = XMLloadfloat(canopy_node, "cluster_height_max_spread");
+    if (new_cluster_height_max_spread != nullvalue_f) {
+        cluster_height_max_spread = new_cluster_height_max_spread;
     }
 
     RGBAcolor new_grape_color = XMLloadrgba(canopy_node, "grape_color");
@@ -451,9 +542,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         grape_subdivisions = uint(new_grape_subdivisions);
     }
 
+    int new_grape_subdivisions_spread = XMLloadint(canopy_node, "grape_subdivisions_spread");
+    if (new_grape_subdivisions_spread != nullvalue_i) {
+        grape_subdivisions_spread = uint(new_grape_subdivisions_spread);
+    }
+
     float new_plant_spacing = XMLloadfloat(canopy_node, "plant_spacing");
     if (new_plant_spacing != nullvalue_f) {
         plant_spacing = new_plant_spacing;
+    }
+
+    float new_plant_spacing_spread = XMLloadfloat(canopy_node, "plant_spacing_spread");
+    if (new_plant_spacing_spread != nullvalue_f) {
+        plant_spacing_spread = new_plant_spacing_spread;
     }
 
     float new_row_spacing = XMLloadfloat(canopy_node, "row_spacing");
@@ -461,9 +562,19 @@ void BaseGrapeVineParameters::readParametersFromXML(const pugi::xml_node canopy_
         row_spacing = new_row_spacing;
     }
 
+    float new_row_spacing_spread = XMLloadfloat(canopy_node, "row_spacing_spread");
+    if (new_row_spacing_spread != nullvalue_f) {
+        row_spacing_spread = new_row_spacing_spread;
+    }
+
     int2 new_plant_count = XMLloadint2(canopy_node, "plant_count");
     if (new_plant_count.x != nullvalue_i && new_plant_count.y != nullvalue_i) {
         plant_count = new_plant_count;
+    }
+
+    float new_canopy_rotation_spread = XMLloadfloat(canopy_node, "canopy_rotation_spread");
+    if (new_canopy_rotation_spread != nullvalue_f) {
+        canopy_rotation_spread = new_canopy_rotation_spread;
     }
 }
 
@@ -534,6 +645,7 @@ SplitGrapevineParameters::SplitGrapevineParameters() : BaseGrapeVineParameters()
     cordon_radius = 0.02;
 
     cordon_spacing = 1.f;
+    cordon_spacing_spread = 0;
 
     shoot_length = 1.2;
 
@@ -542,8 +654,10 @@ SplitGrapevineParameters::SplitGrapevineParameters() : BaseGrapeVineParameters()
     shoots_per_cordon = 10;
 
     shoot_angle_tip = 0.4*M_PI;
+    shoot_angle_tip_spread = 0;
 
     shoot_angle_base = 0.;
+    shoot_angle_base_spread = 0;
 
     leaf_spacing_fraction = 0.6;
 
@@ -2481,7 +2595,9 @@ void CanopyGenerator::buildCanopy(const VSPGrapevineParameters &params ){
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
 
-            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*params.plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*params.row_spacing, 0 );
+            float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
+            float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
+            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*row_spacing, 0 );
 
             uint plant_ID = grapevineVSP( params, center );
 
@@ -2513,7 +2629,9 @@ void CanopyGenerator::buildCanopy(const SplitGrapevineParameters &params ){
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
 
-            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*params.plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*params.row_spacing, 0 );
+            float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
+            float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
+            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*row_spacing, 0 );
 
             uint plant_ID = grapevineSplit( params, center );
 
@@ -2545,7 +2663,9 @@ void CanopyGenerator::buildCanopy(const UnilateralGrapevineParameters &params ){
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
 
-            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*params.plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*params.row_spacing, 0 );
+            float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
+            float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
+            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*row_spacing, 0 );
 
             uint plant_ID = grapevineUnilateral( params, center );
 
@@ -2577,7 +2697,9 @@ void CanopyGenerator::buildCanopy(const GobletGrapevineParameters &params ){
     for( int j=0; j<params.plant_count.y; j++ ){
         for( int i=0; i<params.plant_count.x; i++ ){
 
-            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*params.plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*params.row_spacing, 0 );
+            float plant_spacing = params.plant_spacing + getVariation(params.plant_spacing_spread, generator);
+            float row_spacing = params.row_spacing + getVariation(params.row_spacing_spread, generator);
+            vec3 center = params.canopy_origin+make_vec3(-0.5f*canopy_extent.x+(float(i)+0.5f)*plant_spacing, -0.5f*canopy_extent.y+(float(j)+0.5f)*row_spacing, 0 );
 
             uint plant_ID = grapevineGoblet( params, center );
 

--- a/plugins/canopygenerator/src/grapevine.cpp
+++ b/plugins/canopygenerator/src/grapevine.cpp
@@ -157,6 +157,12 @@ uint CanopyGenerator::grapevineVSP(const VSPGrapevineParameters &params, const v
 
     float canopy_rotation = params.canopy_rotation + getVariation(params.canopy_rotation_spread, generator);
 
+    bool is_dead = false;
+    if( params.dead_probability > 0 ){
+        float random_draw = context->randu();
+        is_dead = random_draw <= params.dead_probability;
+    }
+
     //------ trunks -------//
 
     float trunk_radius = params.trunk_radius + getVariation(params.trunk_radius_spread, generator);
@@ -356,6 +362,11 @@ uint CanopyGenerator::grapevineVSP(const VSPGrapevineParameters &params, const v
                 context->setPrimitiveData( U, "element_label", "cane");
             }
 
+            if( is_dead ){
+                // Don't add grapes and leaves
+                continue;
+            }
+
             //grape clusters
             float grape_radius = params.grape_radius + getVariation(params.grape_radius_spread, generator);
             float cluster_radius = params.cluster_radius + getVariation(params.cluster_radius_spread, generator);
@@ -456,6 +467,12 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
     std::uniform_real_distribution<float> unif_distribution;
 
     float canopy_rotation = params.canopy_rotation + getVariation(params.canopy_rotation_spread, generator);
+
+    bool is_dead = false;
+    if( params.dead_probability > 0 ){
+        float random_draw = context->randu();
+        is_dead = random_draw <= params.dead_probability;
+    }
 
     //------ trunks -------//
 
@@ -713,6 +730,11 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
                 U = context->getObjectPrimitiveUUIDs(objID);
                 UUID_branch_plant.insert(UUID_branch_plant.end(), U.begin(), U.end() );
 
+                if( is_dead ){
+                    // Don't add grapes and leaves
+                    continue;
+                }
+
                 //grape clusters
                 float grape_radius = params.grape_radius + getVariation(params.grape_radius_spread, generator);
                 float cluster_radius = params.cluster_radius + getVariation(params.cluster_radius_spread, generator);
@@ -814,6 +836,12 @@ uint CanopyGenerator::grapevineUnilateral(const UnilateralGrapevineParameters &p
 
     float cost = cosf(canopy_rotation);
     float sint = sinf(canopy_rotation);
+
+    bool is_dead = false;
+    if( params.dead_probability > 0 ){
+        float random_draw = context->randu();
+        is_dead = random_draw <= params.dead_probability;
+    }
 
     //------ trunks -------//
 
@@ -937,6 +965,11 @@ uint CanopyGenerator::grapevineUnilateral(const UnilateralGrapevineParameters &p
         U = context->getObjectPrimitiveUUIDs(objID);
         UUID_branch_plant.insert(UUID_branch_plant.end(), U.begin(), U.end() );
 
+        if( is_dead ){
+            // Don't add grapes and leaves
+            continue;
+        }
+
         //grape clusters
         float grape_radius = params.grape_radius + getVariation(params.grape_radius_spread, generator);
         float cluster_radius = params.cluster_radius + getVariation(params.cluster_radius_spread, generator);
@@ -1033,6 +1066,12 @@ uint CanopyGenerator::grapevineGoblet(const GobletGrapevineParameters &params, c
     float cost = cosf(canopy_rotation);
     float sint = sinf(canopy_rotation);
 
+    bool is_dead = false;
+    if( params.dead_probability > 0 ){
+        float random_draw = context->randu();
+        is_dead = random_draw <= params.dead_probability;
+    }
+
     //------ trunks -------//
 
     float trunk_radius = params.trunk_radius + getVariation(params.trunk_radius_spread, generator);
@@ -1115,6 +1154,11 @@ uint CanopyGenerator::grapevineGoblet(const GobletGrapevineParameters &params, c
             objID = context->addTubeObject(wood_subdivisions,tmp,rad_pshoot, params.wood_texture_file.c_str() );
             U = context->getObjectPrimitiveUUIDs(objID);
             UUID_branch_plant.insert(UUID_branch_plant.end(), U.begin(), U.end() );
+
+            if( is_dead ){
+                // Don't add grapes and leaves
+                continue;
+            }
 
             //grape clusters
             float grape_radius = params.grape_radius + getVariation(params.grape_radius_spread, generator);

--- a/plugins/canopygenerator/src/grapevine.cpp
+++ b/plugins/canopygenerator/src/grapevine.cpp
@@ -199,6 +199,7 @@ uint CanopyGenerator::grapevineVSP(const VSPGrapevineParameters &params, const v
 
     float cordon_height = params.cordon_height + getVariation(params.cordon_height_spread, generator);
     float cordon_radius = params.cordon_radius + getVariation(params.cordon_radius_spread, generator);
+    float cordon_length = params.cordon_length + getVariation(params.cordon_length_spread, generator);
 
     float diff = cordon_height-trunk_height;
 
@@ -212,13 +213,13 @@ uint CanopyGenerator::grapevineVSP(const VSPGrapevineParameters &params, const v
     std::vector<float> rad_cordw;
     rad_cordw.push_back(cordon_radius);
     std::vector<vec3> pos_cordw;
-    pos_cordw.push_back(make_vec3(0.01f*0.5f*params.plant_spacing*cost,0.01f*0.5f*params.plant_spacing*sint,0.95*trunk_height));
+    pos_cordw.push_back(make_vec3(0.01f*cordon_length*cost,0.01f*cordon_length*sint,0.95*trunk_height));
     vec3 n_start = sphere2cart(make_SphericalCoord(cordon_height,0.4f*M_PI*(1+getVariation(0.2,generator)),getVariation(0.2f*M_PI,generator)));
     vec3 n_end = make_vec3(0.5f*cordon_height,0,0);
 
     for( int i=1; i<Ncord; i++ ){
         float frac = float(i)/float(Ncord-1);
-        vec3 n = spline_interp3( frac, pos_cordw.front(), n_start, make_vec3(0.5f*params.plant_spacing*cost,0.5f*params.plant_spacing*sint,trunk_height+diff),n_end);
+        vec3 n = spline_interp3( frac, pos_cordw.front(), n_start, make_vec3(cordon_length*cost,cordon_length*sint,trunk_height+diff),n_end);
         pos_cordw.push_back(n);
         rad_cordw.push_back( cordon_radius*(1.f-0.6f*frac) );
     }
@@ -236,13 +237,13 @@ uint CanopyGenerator::grapevineVSP(const VSPGrapevineParameters &params, const v
     std::vector<float> rad_corde;
     rad_corde.push_back(cordon_radius);
     std::vector<vec3> pos_corde;
-    pos_corde.push_back(make_vec3(-0.01f*0.5f*params.plant_spacing*cost,-0.01f*0.5f*params.plant_spacing*sint,0.95f*trunk_height));
+    pos_corde.push_back(make_vec3(-0.01f*cordon_length*cost,-0.01f*cordon_length*sint,0.95f*trunk_height));
     n_start = sphere2cart(make_SphericalCoord(cordon_height,0.4f*M_PI*(1+getVariation(0.2,generator)),M_PI+getVariation(0.2*M_PI,generator)));
     n_end = make_vec3(-0.5f*cordon_height,0,0);
 
     for( int i=1; i<Ncord; i++ ){
         float frac = float(i)/float(Ncord-1);
-        vec3 n = spline_interp3( frac, pos_corde.front(), n_start, make_vec3(-0.5f*params.plant_spacing*cost,-0.5f*params.plant_spacing*sint,trunk_height+diff),n_end);
+        vec3 n = spline_interp3( frac, pos_corde.front(), n_start, make_vec3(-cordon_length*cost,-cordon_length*sint,trunk_height+diff),n_end);
         pos_corde.push_back(n);
         rad_corde.push_back( cordon_radius*(1.f-0.6f*frac) );
     }
@@ -322,10 +323,12 @@ uint CanopyGenerator::grapevineVSP(const VSPGrapevineParameters &params, const v
             uint Nz = 2*wood_subdivisions;
             float dz = ((1+getVariation(0.1,generator))*height-cordon_height)/float(Nz);
 
+            float total_cordons_length = 2 * cordon_length;
+
             //position of middle of shoot
-            vec3 cane_mid = cane_base + make_vec3(0.1f*getVariation(params.plant_spacing,generator),0.1f*getVariation(params.plant_spacing,generator),0.75f*Nz*dz);
+            vec3 cane_mid = cane_base + make_vec3(0.1f*getVariation(total_cordons_length,generator),0.1f*getVariation(total_cordons_length,generator),0.75f*Nz*dz);
             //position of end of shoot
-            vec3 cane_end = cane_base + make_vec3(0.15f*getVariation(params.plant_spacing,generator),0.15f*getVariation(params.plant_spacing,generator),Nz*dz);
+            vec3 cane_end = cane_base + make_vec3(0.15f*getVariation(total_cordons_length,generator),0.15f*getVariation(total_cordons_length,generator),Nz*dz);
 
             float zfrac_mid = (cane_mid.z-cane_base.z)/(cane_end.z-cane_base.z);
 
@@ -553,6 +556,8 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
 
     //---- Cordons -----//
 
+    float cordon_length = params.cordon_length + getVariation(params.cordon_length_spread, generator);
+
     std::vector<float> rad_cord;
     rad_cord.push_back(cordon_radius);
     rad_cord.push_back(0.95f*cordon_radius);
@@ -568,9 +573,9 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
     pos_cordnw.push_back(make_vec3(0.85f*0.5f*cordon_spacing*cost+0.025f*sint,0.85f*0.5f*cordon_spacing*sint+0.025f*cost,cordon_height));
     pos_cordnw.push_back(make_vec3(0.95f*0.5f*cordon_spacing*cost+0.075f*sint,0.95f*0.5f*cordon_spacing*sint+0.075f*cost,cordon_height));
     pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+0.12f*sint,0.5f*cordon_spacing*sint+0.12f*cost,cordon_height));
-    pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+0.4f*0.5f*params.plant_spacing*sint,0.5f*cordon_spacing*sint+0.4f*0.5f*params.plant_spacing*cost,0.94f*cordon_height));
-    pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+0.8f*0.5f*params.plant_spacing*sint,0.5f*cordon_spacing*sint+0.8f*0.5f*params.plant_spacing*cost,0.97f*cordon_height));
-    pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+0.5f*params.plant_spacing*sint,0.5f*cordon_spacing*sint+0.5f*params.plant_spacing*cost,cordon_height));
+    pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+0.4f*cordon_length*sint,0.5f*cordon_spacing*sint+0.4f*cordon_length*cost,0.94f*cordon_height));
+    pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+0.8f*cordon_length*sint,0.5f*cordon_spacing*sint+0.8f*cordon_length*cost,0.97f*cordon_height));
+    pos_cordnw.push_back(make_vec3(0.5f*cordon_spacing*cost+cordon_length*sint,0.5f*cordon_spacing*sint+cordon_length*cost,cordon_height));
 
     std::vector<vec3> tmp;
     tmp.resize(pos_cordnw.size());
@@ -586,9 +591,9 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
     pos_cordsw.push_back(make_vec3(0.85f*0.5f*cordon_spacing*cost-0.025f*sint,0.85f*0.5f*cordon_spacing*sint-0.025f*cost,cordon_height));
     pos_cordsw.push_back(make_vec3(0.95f*0.5f*cordon_spacing*cost-0.075f*sint,0.95f*0.5f*cordon_spacing*sint-0.075f*cost,cordon_height));
     pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-0.12f*sint,0.5f*cordon_spacing*sint-0.12f*cost,cordon_height));
-    pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-0.4f*0.5f*params.plant_spacing*sint,0.5f*cordon_spacing*sint-0.4f*0.5f*params.plant_spacing*cost,0.94f*cordon_height));
-    pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-0.8f*0.5f*params.plant_spacing*sint,0.5f*cordon_spacing*sint-0.8f*0.5f*params.plant_spacing*cost,0.97f*cordon_height));
-    pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-0.5f*params.plant_spacing*sint,0.5f*cordon_spacing*sint-0.5f*params.plant_spacing*cost,cordon_height));
+    pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-0.4f*cordon_length*sint,0.5f*cordon_spacing*sint-0.4f*cordon_length*cost,0.94f*cordon_height));
+    pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-0.8f*cordon_length*sint,0.5f*cordon_spacing*sint-0.8f*cordon_length*cost,0.97f*cordon_height));
+    pos_cordsw.push_back(make_vec3(0.5f*cordon_spacing*cost-cordon_length*sint,0.5f*cordon_spacing*sint-cordon_length*cost,cordon_height));
 
     tmp.resize(pos_cordsw.size());
     for( uint i=0; i<pos_cordsw.size(); i++ ){
@@ -605,9 +610,9 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
     pos_cordne.push_back(make_vec3(-0.85f*0.5f*cordon_spacing*cost+0.025f*sint,-0.85f*0.5f*cordon_spacing*sint+0.025f*cost,cordon_height));
     pos_cordne.push_back(make_vec3(-0.95f*0.5f*cordon_spacing*cost+0.075f*sint,-0.95f*0.5f*cordon_spacing*sint+0.075f*cost,cordon_height));
     pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+0.12f*sint,-0.5f*cordon_spacing*sint+0.12f*cost,cordon_height));
-    pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+0.4f*0.5f*params.plant_spacing*sint,-0.5f*cordon_spacing*sint+0.4f*0.5f*params.plant_spacing*cost,0.94f*cordon_height));
-    pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+0.8f*0.5f*params.plant_spacing*sint,-0.5f*cordon_spacing*sint+0.8f*0.5f*params.plant_spacing*cost,0.97f*cordon_height));
-    pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+0.5f*params.plant_spacing*sint,-0.5f*cordon_spacing*sint+0.5f*params.plant_spacing*cost,cordon_height));
+    pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+0.4f*cordon_length*sint,-0.5f*cordon_spacing*sint+0.4f*cordon_length*cost,0.94f*cordon_height));
+    pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+0.8f*cordon_length*sint,-0.5f*cordon_spacing*sint+0.8f*cordon_length*cost,0.97f*cordon_height));
+    pos_cordne.push_back(make_vec3(-0.5f*cordon_spacing*cost+cordon_length*sint,-0.5f*cordon_spacing*sint+cordon_length*cost,cordon_height));
 
     tmp.resize(pos_cordne.size());
     for( uint i=0; i<pos_cordne.size(); i++ ){
@@ -623,9 +628,9 @@ uint CanopyGenerator::grapevineSplit(const SplitGrapevineParameters &params, con
     pos_cordse.push_back(make_vec3(-0.85f*0.5f*cordon_spacing*cost-0.025f*sint,-0.85f*0.5f*cordon_spacing*sint-0.025f*cost,cordon_height));
     pos_cordse.push_back(make_vec3(-0.95f*0.5f*cordon_spacing*cost-0.075f*sint,-0.95f*0.5f*cordon_spacing*sint-0.075f*cost,cordon_height));
     pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-0.12f*sint,-0.5f*cordon_spacing*sint-0.12f*cost,cordon_height));
-    pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-0.4f*0.5f*params.plant_spacing*sint,-0.5f*cordon_spacing*sint-0.4f*0.5f*params.plant_spacing*cost,0.94f*cordon_height));
-    pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-0.8f*0.5f*params.plant_spacing*sint,-0.5f*cordon_spacing*sint-0.8f*0.5f*params.plant_spacing*cost,0.97f*cordon_height));
-    pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-0.5f*params.plant_spacing*sint,-0.5f*cordon_spacing*sint-0.5f*params.plant_spacing*cost,cordon_height));
+    pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-0.4f*cordon_length*sint,-0.5f*cordon_spacing*sint-0.4f*cordon_length*cost,0.94f*cordon_height));
+    pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-0.8f*cordon_length*sint,-0.5f*cordon_spacing*sint-0.8f*cordon_length*cost,0.97f*cordon_height));
+    pos_cordse.push_back(make_vec3(-0.5f*cordon_spacing*cost-cordon_length*sint,-0.5f*cordon_spacing*sint-cordon_length*cost,cordon_height));
 
     tmp.resize(pos_cordse.size());
     for( uint i=0; i<pos_cordse.size(); i++ ){
@@ -843,6 +848,8 @@ uint CanopyGenerator::grapevineUnilateral(const UnilateralGrapevineParameters &p
         is_dead = random_draw <= params.dead_probability;
     }
 
+    float cordon_length = params.cordon_length + getVariation(params.cordon_length_spread, generator);
+
     //------ trunks -------//
 
     float trunk_radius = params.trunk_radius + getVariation(params.trunk_radius_spread, generator);
@@ -856,12 +863,12 @@ uint CanopyGenerator::grapevineUnilateral(const UnilateralGrapevineParameters &p
     rad_main.push_back(0.95f*trunk_radius);
     rad_main.push_back(0.1*trunk_radius);
     std::vector<vec3> pos_main;
-    pos_main.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius)*sint,0.0));
-    pos_main.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius)*sint,0.2f*trunk_height));
-    pos_main.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius)*sint,0.22f*trunk_height));
-    pos_main.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius)*sint,0.6f*trunk_height));
-    pos_main.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius)*sint,0.96f*trunk_height));
-    pos_main.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius)*sint,trunk_height));
+    pos_main.push_back(make_vec3((-cordon_length+0.5*trunk_radius)*cost,(-cordon_length+0.5*trunk_radius)*sint,0.0));
+    pos_main.push_back(make_vec3((-cordon_length+0.5*trunk_radius)*cost,(-cordon_length+0.5*trunk_radius)*sint,0.2f*trunk_height));
+    pos_main.push_back(make_vec3((-cordon_length+0.5*trunk_radius)*cost,(-cordon_length+0.5*trunk_radius)*sint,0.22f*trunk_height));
+    pos_main.push_back(make_vec3((-cordon_length+0.5*trunk_radius)*cost,(-cordon_length+0.5*trunk_radius)*sint,0.6f*trunk_height));
+    pos_main.push_back(make_vec3((-cordon_length+0.5*trunk_radius)*cost,(-cordon_length+0.5*trunk_radius)*sint,0.96f*trunk_height));
+    pos_main.push_back(make_vec3((-cordon_length+0.5*trunk_radius)*cost,(-cordon_length+0.5*trunk_radius)*sint,trunk_height));
 
     for( uint i=0; i<rad_main.size(); i++ ){
         pos_main.at(i) = pos_main.at(i) + origin;
@@ -877,6 +884,8 @@ uint CanopyGenerator::grapevineUnilateral(const UnilateralGrapevineParameters &p
     float cordon_height = params.cordon_height + getVariation(params.cordon_height_spread, generator);
     float cordon_radius = params.cordon_radius + getVariation(params.cordon_radius_spread, generator);
 
+    float total_cordons_length = 2 * cordon_length;
+
     float diff = cordon_height-trunk_height;
 
     //Cordon
@@ -889,13 +898,13 @@ uint CanopyGenerator::grapevineUnilateral(const UnilateralGrapevineParameters &p
     rad_cord.push_back(0.6*cordon_radius);
     rad_cord.push_back(0.2f*cordon_radius);
     std::vector<vec3> pos_cord;
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+0.01f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+0.01f*params.plant_spacing)*sint,0.95*trunk_height));
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+0.05f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+0.05f*params.plant_spacing)*sint,trunk_height+0.1f*diff));
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+0.15f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+0.15f*params.plant_spacing)*sint,trunk_height+0.65f*diff));
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+0.45f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+0.45f*params.plant_spacing)*sint,trunk_height+0.95f*diff));
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+0.6f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+0.6f*params.plant_spacing)*sint,trunk_height+1.05f*diff));
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+0.85f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+0.85f*params.plant_spacing)*sint,trunk_height+diff));
-    pos_cord.push_back(make_vec3((-0.5*params.plant_spacing+0.5*trunk_radius+1.0f*params.plant_spacing)*cost,(-0.5*params.plant_spacing+0.5*trunk_radius+1.0f*params.plant_spacing)*sint,trunk_height+diff));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+0.01f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+0.01f*total_cordons_length)*sint,0.95*trunk_height));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+0.05f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+0.05f*total_cordons_length)*sint,trunk_height+0.1f*diff));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+0.15f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+0.15f*total_cordons_length)*sint,trunk_height+0.65f*diff));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+0.45f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+0.45f*total_cordons_length)*sint,trunk_height+0.95f*diff));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+0.6f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+0.6f*total_cordons_length)*sint,trunk_height+1.05f*diff));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+0.85f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+0.85f*total_cordons_length)*sint,trunk_height+diff));
+    pos_cord.push_back(make_vec3((-cordon_length+0.5*trunk_radius+1.0f*total_cordons_length)*cost,(-cordon_length+0.5*trunk_radius+1.0f*total_cordons_length)*sint,trunk_height+diff));
 
     std::vector<vec3> tmp;
     tmp.resize(pos_cord.size());

--- a/plugins/canopygenerator/xml/grapevine.xml
+++ b/plugins/canopygenerator/xml/grapevine.xml
@@ -1,0 +1,100 @@
+<?xml version=1.0?>
+
+<helios>
+	<canopygenerator>
+		<VSPGrapevineParameters>
+			<leaf_width> 0.18 </leaf_width>
+			<leaf_subdivisions> 1 1 </leaf_subdivisions>
+			<leaf_texture_file> plugins/canopygenerator/textures/GrapeLeaf.png </leaf_texture_file>
+			<wood_texture_file> plugins/canopygenerator/textures/wood.jpg </wood_texture_file>
+			<wood_subdivisions> 10 </wood_subdivisions>
+			<trunk_height> 0.7 </trunk_height>
+			<trunk_radius> 0.05 </trunk_radius>
+			<cordon_height> 0.9 </cordon_height>
+			<cordon_radius> 0.02 </cordon_radius>
+			<shoot_length> 0.9 </shoot_length>
+			<shoot_radius> 0.005 </shoot_radius>
+			<shoots_per_cordon> 10 </shoots_per_cordon>
+			<leaf_spacing_fraction> 0.5 </leaf_spacing_fraction>
+			<grape_radius> 0.0075 </grape_radius>
+			<cluster_radius> 0.03 </cluster_radius>
+			<cluster_height_max> 0.15 </cluster_height_max>
+			<grape_color> 0.18 0.2 0.25 </grape_color>
+			<grape_subdivisions> 8 </grape_subdivisions>
+			<canopy_origin> 0 0 0 </canopy_origin>
+			<canopy_rotation> 0 </canopy_rotation>
+		</VSPGrapevineParameters>
+
+		<SplitGrapevineParameters>
+			<leaf_width> 0.18 </leaf_width>
+			<leaf_subdivisions> 1 1 </leaf_subdivisions>
+			<leaf_texture_file> plugins/canopygenerator/textures/GrapeLeaf.png </leaf_texture_file>
+			<wood_texture_file> plugins/canopygenerator/textures/wood.jpg </wood_texture_file>
+			<wood_subdivisions> 10 </wood_subdivisions>
+			<trunk_height> 1.3 </trunk_height>
+			<trunk_radius> 0.05 </trunk_radius>
+			<cordon_height> 1.5 </cordon_height>
+			<cordon_radius> 0.02 </cordon_radius>
+			<cordon_spacing> 1.0 </cordon_spacing>
+			<shoot_length> 1.2 </shoot_length>
+			<shoot_radius> 0.0025 </shoot_radius>
+			<shoots_per_cordon> 10 </shoots_per_cordon>
+			<shoot_angle_tip> 1.256637 <!-- 0.4 * pi --> </shoot_angle_tip>
+			<shoot_angle_base> 0 </shoot_angle_base>
+			<leaf_spacing_fraction> 0.6 </leaf_spacing_fraction>
+			<grape_radius> 0.0075 </grape_radius>
+			<cluster_radius> 0.03 </cluster_radius>
+			<cluster_height_max> 0.1 </cluster_height_max>
+			<grape_color> 0.18 0.2 0.25 </grape_color>
+			<grape_subdivisions> 8 </grape_subdivisions>
+			<canopy_origin> 0 0 0 </canopy_origin>
+			<canopy_rotation> 0 </canopy_rotation>
+		</SplitGrapevineParameters>
+
+		<UnilateralGrapevineParameters>
+			<leaf_width> 0.18 </leaf_width>
+			<leaf_subdivisions> 1 1 </leaf_subdivisions>
+			<leaf_texture_file> plugins/canopygenerator/textures/GrapeLeaf.png </leaf_texture_file>
+			<wood_texture_file> plugins/canopygenerator/textures/wood.jpg </wood_texture_file>
+			<wood_subdivisions> 10 </wood_subdivisions>
+			<trunk_height> 0.7 </trunk_height>
+			<trunk_radius> 0.05 </trunk_radius>
+			<cordon_height> 0.9 </cordon_height>
+			<cordon_radius> 0.04 </cordon_radius>
+			<shoot_length> 0.9 </shoot_length>
+			<shoot_radius> 0.0025 </shoot_radius>
+			<shoots_per_cordon> 20 </shoots_per_cordon>
+			<leaf_spacing_fraction> 0.6 </leaf_spacing_fraction>
+			<grape_radius> 0.0075 </grape_radius>
+			<cluster_radius> 0.03 </cluster_radius>
+			<cluster_height_max> 0.1 </cluster_height_max>
+			<grape_color> 0.18 0.2 0.25 </grape_color>
+			<grape_subdivisions> 8 </grape_subdivisions>
+			<canopy_origin> 0 0 0 </canopy_origin>
+			<canopy_rotation> 0 </canopy_rotation>
+		</UnilateralGrapevineParameters>
+
+		<GobletGrapevineParameters>
+			<leaf_width> 0.18 </leaf_width>
+			<leaf_subdivisions> 1 1 </leaf_subdivisions>
+			<leaf_texture_file> plugins/canopygenerator/textures/GrapeLeaf.png </leaf_texture_file>
+			<wood_texture_file> plugins/canopygenerator/textures/wood.jpg </wood_texture_file>
+			<wood_subdivisions> 10 </wood_subdivisions>
+			<trunk_height> 0.7 </trunk_height>
+			<trunk_radius> 0.05 </trunk_radius>
+			<cordon_height> 0.9 </cordon_height>
+			<cordon_radius> 0.02 </cordon_radius>
+			<shoot_length> 0.9 </shoot_length>
+			<shoot_radius> 0.0025 </shoot_radius>
+			<shoots_per_cordon> 10 </shoots_per_cordon>
+			<leaf_spacing_fraction> 0.6 </leaf_spacing_fraction>
+			<grape_radius> 0.0075 </grape_radius>
+			<cluster_radius> 0.03 </cluster_radius>
+			<cluster_height_max> 0.1 </cluster_height_max>
+			<grape_color> 0.18 0.2 0.25 </grape_color>
+			<grape_subdivisions> 8 </grape_subdivisions>
+			<canopy_origin> 0 0 0 </canopy_origin>
+			<canopy_rotation> 0 </canopy_rotation>
+		</GobletGrapevineParameters>
+	</canopygenerator>
+</helios>

--- a/plugins/weberpenntree/include/WeberPennTree.h
+++ b/plugins/weberpenntree/include/WeberPennTree.h
@@ -25,13 +25,13 @@ struct WeberPennTreeParameters{
   int Shape;
 
   // Fractional branchless area at tree base
-  float BaseSize;
+  float BaseSize, BaseSizeV;
 
   // Number of splits at tree base
-  uint BaseSplits;
+  uint BaseSplits, BaseSplitsV;
 
   // Fractional height of split (if BaseSplits>0)
-  float BaseSplitSize;
+  float BaseSplitSize, BaseSplitSizeV;
 
   // Size and scaling of tree
   float Scale, ScaleV, ZScale, ZScaleV;
@@ -212,8 +212,10 @@ class WeberPennTree{
       \param[in] "offset_child" Length in meters of the child along the parent's branch
       \param[in] "phirot" Angle of rotation of child about parent's z-axis
       \param[in] "scale" Tree scaling factor
+      \param[in] "base_size" Base size computed (with the configured variance) for this specific tree instance
+      \param[in] "base_splits" Number of base splits computed (with the configured variance) for this specific tree instance
   */
-  void recursiveBranch( WeberPennTreeParameters parameters, uint n, uint seg_start, helios::vec3 base_position, helios::vec3 parent_normal, helios::SphericalCoord child_rotation, float length_parent, float radius_parent, float offset_child, helios::vec3 origin, float scale, const uint leaf_template );
+  void recursiveBranch( WeberPennTreeParameters parameters, uint n, uint seg_start, helios::vec3 base_position, helios::vec3 parent_normal, helios::SphericalCoord child_rotation, float length_parent, float radius_parent, float offset_child, helios::vec3 origin, float scale, const uint leaf_template, float base_size, uint base_splits );
 
   float getVariation( float V );
  

--- a/samples/tree_orchard/CMakeLists.txt
+++ b/samples/tree_orchard/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Helios standard CMakeLists.txt file version 1.9
+cmake_minimum_required(VERSION 3.15)
+project(helios)
+
+#-------- USER INPUTS ---------#
+
+#provide the path to Helios base directory, either as an absolut path or a path relative to the location of this file
+set( BASE_DIRECTORY "../.." )
+	
+#define the name of the executable to be created
+set( EXECUTABLE_NAME "tree_orchard" )
+
+#provide name of source file(s) (separate multiple file names with semicolon)
+set( SOURCE_FILES "main.cpp" )
+
+#specify which plug-ins to use (separate plug-in names with semicolon)
+set( PLUGINS "weberpenntree;visualizer;" )
+
+
+#-------- DO NOT MODIFY ---------#
+include( "${BASE_DIRECTORY}/core/CMake_project.txt" )

--- a/samples/tree_orchard/config/tree.xml
+++ b/samples/tree_orchard/config/tree.xml
@@ -1,0 +1,43 @@
+<?xml version=1.0?>
+
+<helios>
+	<WeberPennTree label="CustomOlive">
+		<Shape> 1 </Shape>
+		<BaseSize> 0.4 </BaseSize>
+		<BaseSizeV> 0.1 </BaseSizeV>
+		<BaseSplits> 3 </BaseSplits>
+		<BaseSplitsV> 2 </BaseSplitsV>
+		<BaseSplitSize> 0.4 </BaseSplitSize>
+		<BaseSplitSizeV> 0.1 </BaseSplitSizeV>
+		<Scale> 2 </Scale>
+		<ScaleV> 0.5 </ScaleV>
+		<ZScale> 2 </ZScale>
+		<ZScaleV> 0.5 </ZScaleV>
+		<Ratio> 0.03 </Ratio>
+		<RatioPower> 1. </RatioPower>
+		<Lobes> 7 </Lobes>
+		<LobeDepth> 0.1 </LobeDepth>
+		<Flare> 0 </Flare>
+		<Levels> 3 </Levels>
+		<nSegSplits> 0 0 0 0 </nSegSplits>
+		<nSplitAngle> 33 30 0 0 </nSplitAngle>
+		<nSplitAngleV> 20 10 0 0 </nSplitAngleV>
+		<nCurveRes> 4 4 4 0 </nCurveRes>
+		<nCurve> -50 -60 -60 0 </nCurve>
+		<nCurveV> 20 20 20 0 </nCurveV>
+		<nCurveBack> 0 0 0 0 </nCurveBack>
+		<nLength> 1 0.5 0.3 0 </nLength>
+		<nLengthV> 0 0.5 0.5 0 </nLengthV>
+		<nTaper> 1 1 1 0 </nTaper>
+		<nDownAngle> 65 45 45 35 </nDownAngle>
+		<nDownAngleV> 20 20 20 20 </nDownAngleV>
+		<nRotate> 0 0 0 0 </nRotate>
+		<nRotateV> 15 30 45 60 </nRotateV>
+		<nBranches> 30 35 20 0 </nBranches>
+		<Leaves> 10 </Leaves>
+		<LeafFile> plugins/weberpenntree/leaves/OliveLeaf.png </LeafFile>
+		<LeafScale> 0.08 </LeafScale>
+		<LeafScaleX> 0.1 </LeafScaleX>
+		<WoodFile> plugins/weberpenntree/wood/wood.jpg </WoodFile>
+	</WeberPennTree>
+</helios>

--- a/samples/tree_orchard/main.cpp
+++ b/samples/tree_orchard/main.cpp
@@ -1,0 +1,65 @@
+#include "WeberPennTree.h"
+#include "Visualizer.h"
+
+using namespace helios;
+
+const char *config_file_path = "../config/tree.xml";
+const char *custom_tree_label = "CustomOlive";
+
+/* Orchard parameters */
+
+int num_rows = 4;
+float row_spacing = 2.5;
+float row_spacing_spread = 0.05;
+int num_trees_per_row = 10;
+float tree_spacing = 1.5;
+float tree_spacing_spread = 0.3;
+
+int main(int argc, char *argv[])
+{
+	Context context;
+	WeberPennTree weberpenntree(&context);
+
+	// Seed the random number generators
+	unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+	context.seedRandomGenerator(seed);
+	weberpenntree.seedRandomGenerator(seed);
+
+	/* Load the config file to read the tree geometry parameters */
+	weberpenntree.loadXML(config_file_path);
+
+	/* Build the orchard */
+	for (int row_index = 0; row_index < num_rows; row_index++) {
+		for (int tree_index = 0; tree_index < num_trees_per_row; tree_index++) {
+			vec3 tree_position = make_vec3(tree_index * tree_spacing + context.randu(-tree_spacing_spread, tree_spacing_spread), row_index * row_spacing + context.randu(-row_spacing_spread, row_spacing_spread), 0);
+			/* uint id = */weberpenntree.buildTree(custom_tree_label, tree_position);
+		}
+	}
+
+
+	/* Set the Visualizer */
+
+	Visualizer vis(1000);
+	// Direction of the sun
+	SphericalCoord sun_dir;
+	sun_dir = make_SphericalCoord(20 * M_PI / 180.f, 205 * M_PI / 180.f);
+	vis.setLightDirection(sphere2cart(sun_dir));
+	vis.setLightingModel(Visualizer::LIGHTING_PHONG_SHADOWED);
+
+	// Get the context domain bounding coordinates
+	helios::vec2 x_bounds;
+	helios::vec2 y_bounds;
+	helios::vec2 z_bounds;
+	context.getDomainBoundingBox(x_bounds, y_bounds, z_bounds);
+	float x_range = x_bounds.y - x_bounds.x;
+	float y_range = y_bounds.y - y_bounds.x;
+
+	vec3 origin(x_bounds.x + x_range / 2, y_bounds.x + y_range / 2, 0);
+
+	vis.addSkyDomeByCenter(max(std::vector<int>(x_range * 4, y_range * 4)), origin, 30, "plugins/visualizer/textures/SkyDome_clouds.jpg");
+
+	vis.buildContextGeometry(&context);
+	vis.plotInteractive();
+
+	return EXIT_SUCCESS;
+}

--- a/samples/vineyard/CMakeLists.txt
+++ b/samples/vineyard/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Helios standard CMakeLists.txt file version 1.9
+cmake_minimum_required(VERSION 3.15)
+project(helios)
+
+#-------- USER INPUTS ---------#
+
+#provide the path to Helios base directory, either as an absolute path or a path relative to the location of this file
+set( BASE_DIRECTORY "../.." )
+
+#define the name of the executable to be created
+set( EXECUTABLE_NAME "vineyard" )
+
+#provide name of source file(s) (separate multiple file names with semicolon)
+set( SOURCE_FILES "main.cpp" )
+
+#specify which plug-ins to use (separate plug-in names with semicolon)
+set( PLUGINS "canopygenerator;visualizer;" )
+
+
+#-------- DO NOT MODIFY ---------#
+include( "${BASE_DIRECTORY}/core/CMake_project.txt" )
+

--- a/samples/vineyard/config/vine.xml
+++ b/samples/vineyard/config/vine.xml
@@ -1,0 +1,53 @@
+<?xml version=1.0?>
+
+<helios>
+	<canopygenerator>
+		<VSPGrapevineParameters>
+			<leaf_width> 0.18 </leaf_width>
+			<leaf_width_spread> 0.09 </leaf_width_spread>
+			<leaf_subdivisions> 1 1 </leaf_subdivisions>
+			<leaf_texture_file> plugins/canopygenerator/textures/GrapeLeaf.png </leaf_texture_file>
+			<wood_texture_file> plugins/canopygenerator/textures/wood.jpg </wood_texture_file>
+			<wood_subdivisions> 10 </wood_subdivisions>
+			<wood_subdivisions_spread> 3 </wood_subdivisions_spread>
+			<trunk_height> 0.7 </trunk_height>
+			<trunk_height_spread> 0.3 </trunk_height_spread>
+			<trunk_radius> 0.05 </trunk_radius>
+			<trunk_radius_spread> 0.01 </trunk_radius_spread>
+			<cordon_length> 1 </cordon_length>
+			<cordon_length_spread> 0.2 </cordon_length_spread>
+			<cordon_height> 0.9 </cordon_height>
+			<cordon_height_spread> 0.3 </cordon_height_spread>
+			<cordon_radius> 0.02 </cordon_radius>
+			<cordon_radius_spread> 0.005 </cordon_radius_spread>
+			<shoot_length> 0.9 </shoot_length>
+			<shoot_length_spread> 0.3 </shoot_length_spread>
+			<shoot_radius> 0.005 </shoot_radius>
+			<shoot_radius_spread> 0.001 </shoot_radius_spread>
+			<shoots_per_cordon> 10 </shoots_per_cordon>
+			<shoots_per_cordon_spread> 4 </shoots_per_cordon_spread>
+			<leaf_spacing_fraction> 0.5 </leaf_spacing_fraction>
+			<leaf_spacing_fraction_spread> 0.1 </leaf_spacing_fraction_spread>
+			<grape_radius> 0.0075 </grape_radius>
+			<grape_radius_spread> 0.002 </grape_radius_spread>
+			<cluster_radius> 0.03 </cluster_radius>
+			<cluster_radius_spread> 0.005 </cluster_radius_spread>
+			<cluster_height_max> 0.15 </cluster_height_max>
+			<cluster_height_max_spread> 0.03 </cluster_height_max_spread>
+			<grape_color> 0.18 0.2 0.25 </grape_color>
+			<grape_subdivisions> 8 </grape_subdivisions>
+			<grape_subdivisions_spread> 3 </grape_subdivisions_spread>
+			<dead_probability> 0.2 </dead_probability>
+			<canopy_origin> 0 0 0 </canopy_origin>
+			<canopy_rotation> 0 </canopy_rotation>
+			<!-- The following parameters are only used when building a whole canopy (not just an individual plant)-->
+			<canopy_rotation_spread> 0.05 </canopy_rotation_spread>
+			<plant_spacing> 2 </plant_spacing>
+			<plant_spacing_spread> 0.1 </plant_spacing_spread>
+			<row_spacing> 2.5 </row_spacing>
+			<row_spacing_spread> 0.05 </row_spacing_spread>
+			<plant_count> 5 3 </plant_count>
+			<missing_plant_probability> 0.1 </missing_plant_probability>
+		</VSPGrapevineParameters>
+	</canopygenerator>
+</helios>

--- a/samples/vineyard/main.cpp
+++ b/samples/vineyard/main.cpp
@@ -1,0 +1,83 @@
+/**
+ * The goal of this sample project is to demonstrate how to build vine stocks based on parameters defined in a configuration file.
+ * First we build a fully configured canopy (multiple straight rows of plants), then we build an individual vine stock, and finally we use the flexibility of
+ * individual plant generation to build a circle arc of vine stocks.
+ */
+
+#include "CanopyGenerator.h"
+#include "Visualizer.h"
+
+using namespace helios;
+
+#define CONFIG_DIR "../config/"
+#define VINE_CONFIG_FILE_NAME "vine.xml"
+
+int main()
+{
+	Context context;
+	CanopyGenerator canopy_generator(&context);
+
+	/**
+	 * Build the plants
+	 */
+
+	/* Seed the random number generators */
+	unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+	context.seedRandomGenerator(seed);
+	canopy_generator.seedRandomGenerator(seed);
+
+	/* Read the vine config file and build the canopy
+	Each set of parameters written in the file will be stored in our CanopyGenerator. Whenever we call CanopyGenerator::buildIndividualPlants() or
+	CanopyGenerator::buildCanopies(), an instance of a single plant or a whole canopy will be built for each set of parameters that is stored. */
+	const char *vine_config_file_path = CONFIG_DIR VINE_CONFIG_FILE_NAME;
+	canopy_generator.loadXML(vine_config_file_path, true);
+
+	/* Build an individual plant based on the same parameters */
+	vec3 vine_stock_position = make_vec3(-7.5, -10, 0);
+	// This builds only one plant if only one set of parameters is configured
+	canopy_generator.buildIndividualPlants(vine_stock_position);
+
+	/* Build an arc of plants based on the same parameters */
+	// Number of vine stocks
+	int num_plants = 8;
+	vec3 circle_center = make_vec3(7.5, 6, 0);
+	float circle_radius = 6;
+	// Total angle coverage of the plants arc
+	float total_arc_angle = 160;
+	// Angle difference between each plant
+	float angle_diff_between_plants = total_arc_angle / num_plants;
+	// The vine parameters. Here we assume there is at least one set of parameters, and we get the last one.
+	BaseCanopyParameters *params = canopy_generator.getCanopyParametersList().back().get();
+	for (int plant_index = 0; plant_index < num_plants; plant_index++) {
+		float angle = deg2rad(plant_index * angle_diff_between_plants);
+		// We modify the parameters here, but beware because they will be saved, overwriting the ones read from the config file
+		params->canopy_rotation = angle + deg2rad(90);
+		vec3 plant_position = make_vec3(circle_center.x + circle_radius * cos(angle), circle_center.y + circle_radius * sin(angle), circle_center.z);
+		canopy_generator.buildIndividualPlants(plant_position);
+	}
+
+	/**
+	 * Build the ground
+	 */
+
+	vec3 origin(0, 0, 0);
+	vec2 extent(30, 30);
+	int2 num_tiles(6, 3);
+	int2 subpatches(4, 4);
+	canopy_generator.buildGround(origin, extent, num_tiles, subpatches, "plugins/canopygenerator/textures/dirt.jpg");
+
+	/**
+	 * Set the Visualizer
+	 */
+
+	SphericalCoord sun_dir;
+	sun_dir = make_SphericalCoord(20 * M_PI / 180.f, 205 * M_PI / 180.f);
+
+	Visualizer vis(1000);
+	vis.setLightDirection(sphere2cart(sun_dir));
+	vis.setLightingModel(Visualizer::LIGHTING_PHONG_SHADOWED);
+	vis.buildContextGeometry(&context);
+	vis.plotInteractive();
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request allows to easily build configurable and realistic tree orchards and vineyards. It contains the following changes:

- Addition of variable range parameters for WeberPenn tree generation
- Addition of a sample project to demonstrate how one could build tree orchards based on a WeberPenn XML configuration
- Handling of parameters that were not parsed from a CanopyGenerator XML configuration for grapevine canopies
- A refactoring of the way canopy types are handled. Now all canopy classes inherit from `BaseCanopyParameters`, and all grapevine canopy classes inherit from  `BaseGrapeVineParameters`. On top of that, parameters read from an XML file are stored so that canopies or individual plants can be built later on. This allows client code to have no knowledge at all about the types of canopies or plants that can be built; this information is exclusively written in the configuration file.
- Addition of variable range parameters for grapevine canopies
- Addition of parameters to create dead plants or to have missing plants (holes) in grapevine canopies
- Addition of parameters to set the cordon length independently from the plant spacing for grapevine canopies. Until now, the plant spacing was used so that there was no discontinuity between neighbor vine stocks. These new parameters allow to potentially have gaps between vine stocks, or even have them overlap with each other (if the cordon length is greater than the plant spacing).
- Addition of a sample project to demonstrate how one could build realistic vineyards based on CanopyGenerator XML configuration.

Note that existing client code does not need to be altered in any way because of these changes. They only affect the inner Helios code of WeberPennTree and CanopyGenerator plugins.

For the CanopyGenerator plugin I mainly added features for the grapevine canopies because they are what I am interested in building, and it is quite tedious to reflect the changes for all canopy types. If you think these features (such as dead plant probability or spread parameters) are useful, maybe you can make the changes to implement them for other canopy types as well.

I have not changed the documentation to reflect these changes yet, because if I run doxygen, it makes changes pretty much everywhere, mainly because I have a more up-to-date version. If you accept these changes I can add some information in the documentation and downgrade doxygen to avoid having many changes in all documentation files.

I tried to accommodate to the existing syntax in the files I changed. However in the sample projects I added, I used tabulation indents (mainly because I am used to it and space indentation is very painful to my eyes). I can change it to spaces for consistency if you want.

I also wrote my commit messages with the format I am used to, but let me know if you want me to change them so it complies with your own rules.

Thank you for making such a great Open Source project. I hope my contributions can help people using Helios.