### PR TITLE
WeberPennTree trunk tilt

### DIFF
--- a/plugins/weberpenntree/include/WeberPennTree.h
+++ b/plugins/weberpenntree/include/WeberPennTree.h
@@ -33,6 +33,13 @@ struct WeberPennTreeParameters{
   // Fractional height of split (if BaseSplits>0)
   float BaseSplitSize, BaseSplitSizeV;
 
+  // Tilt of the trunk
+  helios::vec2 BaseTilt, BaseTiltV;
+
+  // x and y spread values for the positions of the nodes along the trunk
+  // If 0, the base will be perfectly straight. Otherwise it will be more winding or crooked.
+  helios::vec2 BaseAlignmentV;
+
   // Size and scaling of tree
   float Scale, ScaleV, ZScale, ZScaleV;
 

--- a/samples/weberpenntree_orchard/config/tree.xml
+++ b/samples/weberpenntree_orchard/config/tree.xml
@@ -9,6 +9,9 @@
 		<BaseSplitsV> 2 </BaseSplitsV>
 		<BaseSplitSize> 0.4 </BaseSplitSize>
 		<BaseSplitSizeV> 0.1 </BaseSplitSizeV>
+		<BaseTilt> 0 0 </BaseTilt>
+		<BaseTiltV> 0.05 0.05 </BaseTiltV>
+		<BaseAlignmentV> 0.05 0.05 </BaseAlignmentV>
 		<Scale> 2 </Scale>
 		<ScaleV> 0.5 </ScaleV>
 		<ZScale> 2 </ZScale>


### PR DESCRIPTION
This PR adds the possibility with the WeberPennTree plugin to tilt the tree trunks so that they are not perfectly vertical, and make them crooked so that they are not perfectly straight.