### PR TITLE
Fix Doxygen refs

### DIFF
--- a/doc/Tutorials.dox
+++ b/doc/Tutorials.dox
@@ -893,7 +893,7 @@
 
 \subsection Tutorial10_rad 2. Radiation model set-up
 
- We can then declare and initialize the \ref RadiationModel class. It's constructor takes a pointer to the \ref Context as an argument, so that it can get model geometry and data, and write calculated values to primitive data.
+ We can then declare and initialize the \ref RadiationModel class. It's constructor takes a pointer to the \ref helios::Context as an argument, so that it can get model geometry and data, and write calculated values to primitive data.
 
  We'll then add a "sun sphere" radiation source in the model using \ref RadiationModel::addSunSphereRadiationSource(). This creates a spherical radiation source with size and distance of the sun, and thus includes penumbral effects. This function with no arguments sets the sun position as vertical, but we'll pass it a \ref helios::SphericalCoord that sets the sun elevation at 60 degrees and azimuth at 45 degrees. The function returns a uint value that gives an ID of the source that we'll use to reference it later.
 

--- a/doc/UserGuide.dox
+++ b/doc/UserGuide.dox
@@ -98,7 +98,7 @@
 
   \section PrereqsHelios Helios Prerequisites
 
-  Before beginning, you will want to familiarize yourself with Helios vector types, which are commonly used in specifying function arguments. These are C++ structures that have two or more data members. For example, a \ref vec3 type has three floating point members: x, y, z. A vec3 is commonly used to represent a Cartesian point in space. More comprehensive information on available vector types is given in Section \ref VecTypes and \ref context_vectors.
+  Before beginning, you will want to familiarize yourself with Helios vector types, which are commonly used in specifying function arguments. These are C++ structures that have two or more data members. For example, a \ref helios::vec3 type has three floating point members: x, y, z. A vec3 is commonly used to represent a Cartesian point in space. More comprehensive information on available vector types is given in Section \ref VecTypes and \ref context_vectors_tutorial.
 
   It may be useful to familiarize yourself with <a href="https://en.wikipedia.org/wiki/Spherical_coordinate_system">spherical coordinate systems</a>, which is how rotation angles are typically specified. It may also be helpful to familiarize yourself with the <a href="https://en.wikipedia.org/wiki/RGB_color_space">RGB color model</a>, which is how custom colors are specified.
 
@@ -568,9 +568,9 @@
  
  <table>
   <tr><th>Primitive</th><th>Description</th><th>Enumeration</th></tr>
-  <tr><td>\ref ::helios::Primitive::Patch "Patch"</td><td>Rectangular polygon with coplanar vertices.  A patch is specified by the (x,y,z) coordinate of its center and by the lengths of its sides in the x- and y-directions.  The default orientation of a patch is horizontal (i.e., it's normal is in the +z direction).</td><td>\ref helios::PrimitiveType::PRIMITIVE\_TYPE\_PATCH "PRIMITIVE_TYPE_PATCH"</td></tr>
-  <tr><td>\ref helios::Triangle "Triangle"</td><td>Triangular polygon specified by its three vertices.</td><td>\ref helios::PrimitiveType::PRIMITIVE\_TYPE\_TRIANGLE "PRIMITIVE_TYPE_TRIANGLE"</td></tr>
-  <tr><td>\ref helios::Voxel "Voxel"</td><td>Parallelpiped or rectangular prism.  A voxel is specified by the (x,y,z) coordinate of its center and by the lengths of its sides in the x-, y-, and z-directions.  The default orientation of a voxel is axis-aligned.</td><td>\ref helios::PrimitiveType::PRIMITIVE\_TYPE\_VOXEL "PRIMITIVE_TYPE_VOXEL"</td></tr>
+<tr><td>Patch</td><td>Rectangular polygon with coplanar vertices.  A patch is specified by the (x,y,z) coordinate of its center and by the lengths of its sides in the x- and y-directions.  The default orientation of a patch is horizontal (i.e., it's normal is in the +z direction).</td><td>\ref helios::PrimitiveType::PRIMITIVE\_TYPE\_PATCH "PRIMITIVE_TYPE_PATCH"</td></tr>
+ <tr><td>Triangle</td><td>Triangular polygon specified by its three vertices.</td><td>\ref helios::PrimitiveType::PRIMITIVE\_TYPE\_TRIANGLE "PRIMITIVE_TYPE_TRIANGLE"</td></tr>
+ <tr><td>Voxel</td><td>Parallelpiped or rectangular prism.  A voxel is specified by the (x,y,z) coordinate of its center and by the lengths of its sides in the x-, y-, and z-directions.  The default orientation of a voxel is axis-aligned.</td><td>\ref helios::PrimitiveType::PRIMITIVE\_TYPE\_VOXEL "PRIMITIVE_TYPE_VOXEL"</td></tr>
  </table>	
  
  \subsection AddingPrims Adding Primitives
@@ -581,7 +581,7 @@
 
  <table>
  <tr><th>Primitive</th><th>Adder function</th></tr>
- <tr><td>\ref helios::Patch "Patch"</td><td>
+ <tr><td>Patch</td><td>
      <ul>
 	<li>\ref helios::Context::addPatch(const helios::vec3 & center, const helios::vec2 & size ) "addPatch( vec3 center, vec2 size )"</li>
 	 <li>\ref helios::Context::addPatch(const helios::vec3 & center, const helios::vec2 & size, const helios::SphericalCoord & rotation  ) "addPatch( vec3 center, vec2 size, SphericalCoord rotation )"</li>
@@ -590,14 +590,14 @@
 	 <li>\ref helios::Context::addPatch(const helios::vec3 & center, const helios::vec2 & size, const helios::SphericalCoord & rotation, const char* texture_file, const helios::vec2 & uv_center, const helios::vec2 & uv_size  ) "addPatch( vec3 center, vec2 size, SphericalCoord rotation, const char* texture_file, vec2 uv_center, vec2 uv_size )"</li>
        </ul>	 
  </td></tr>
- <tr><td>\ref helios::Triangle "Triangle"</td><td>
+ <tr><td>Triangle</td><td>
    	<ul>
 	 <li>\ref helios::Context::addTriangle( const helios::vec3 & vertex0, const helios::vec3 & vertex1, const helios::vec3 & vertex2 ) "addTriangle( vec3 vertex0, vec3 vertex1, vec3 vertex2 )"</li>
 	 <li>\ref helios::Context::addTriangle( const helios::vec3 & vertex0, const helios::vec3 & vertex1, const helios::vec3 & vertex2, const helios::RGBcolor & color ) "addTriangle( vec3 vertex0, vec3 vertex1, vec3 vertex2, RGBcolor color )"</li>
 	 <li>\ref helios::Context::addTriangle( const helios::vec3 & vertex0, const helios::vec3 & vertex1, const helios::vec3 & vertex2, const char* texture_file, const helios::vec2 & uv0, const helios::vec2 & uv1,const helios::vec2 & uv2 ) "addTriangle( vec3 vertex0, vec3 vertex1, vec3 vertex2, const char* texture_file, vec2 uv0, vec2 uv1, vec2 uv2 )"</li>
        </ul>
    </td></tr>
-   <tr>	<td>\ref helios::Voxel "Voxel"</td><td>
+   <tr>	<td>Voxel</td><td>
        <ul>
 	 <li>\ref helios::Context::addVoxel( const helios::vec3 & center, const helios::vec3 & size ) "addVoxel( vec3 center, vec3 size )"</li>
 	 <li>\ref helios::Context::addVoxel( const helios::vec3 & center, const helios::vec3 & size, const float & rotation ) "addVoxel( vec3 center, vec3 size, float rotation )"</li>
@@ -639,7 +639,7 @@
   context.addPatch( center, size, rotation );
  ~~~~~~
 
- This will first rotate the patch by 0.25\f$\pi\f$ rad about the x-axis such that its normal is pointing toward the +y direction, THEN it will apply a clockwise azimuthal rotation of 0.5\f$\pi\f$ rad such that its normal is pointing in the +x direction (which will be its final orientation). Note that in order to have more control over rotations, it is recommended to use the \ref Primitive::rotate() function (see "Primitive Transformations" section below).
+This will first rotate the patch by 0.25\f$\pi\f$ rad about the x-axis such that its normal is pointing toward the +y direction, THEN it will apply a clockwise azimuthal rotation of 0.5\f$\pi\f$ rad such that its normal is pointing in the +x direction (which will be its final orientation). Note that in order to have more control over rotations, it is recommended to use the \ref helios::Context::rotatePrimitive() function (see "Primitive Transformations" section below).
 
  \subsubsection AddingTriangle Adding Triangles
 
@@ -709,9 +709,9 @@
 
  After primitives have been added to the Context, their position, size, and orientation can be further modified through transformations.
 
- The \ref scalePrimitive() function takes a vec3 that denotes a scaling factor to apply in each Cartesian direction (x,y,z). The \ref translatePrimitive() function moves the primitive based on values provided by a vec3 that specifies the distance to translate in the x-, y-, and z-directions.
+ The \ref helios::Context::scalePrimitive() function takes a vec3 that denotes a scaling factor to apply in each Cartesian direction (x,y,z). The \ref helios::Context::translatePrimitive() function moves the primitive based on values provided by a vec3 that specifies the distance to translate in the x-, y-, and z-directions.
 
- The \ref rotatePrimitive() function rotates the primitive about an axis through an angle specified in radians. To rotate about one of the x-, y-, or z-axes, the function can be supplied a string of 'x', 'y', or 'z', respectively. The primitive can also be rotated about an arbitrary axis described by a unit vector argument. By default, the axis passes through the origin, but there is also an option to specify an arbitrary axis of rotation passing through an arbitrary origin point.
+ The \ref helios::Context::rotatePrimitive() function rotates the primitive about an axis through an angle specified in radians. To rotate about one of the x-, y-, or z-axes, the function can be supplied a string of 'x', 'y', or 'z', respectively. The primitive can also be rotated about an arbitrary axis described by a unit vector argument. By default, the axis passes through the origin, but there is also an option to specify an arbitrary axis of rotation passing through an arbitrary origin point.
 
  It is important to note that the order in which transformations are applied matters. Each transformation is applied based on the primitives current state. Rotating a primitive centered about the origin will cause the primitive to rotate about its own center. However, if a primitive is first translated then rotated, the primitive will be rotated about the origin (0,0,0), which does not necessarily coincide with the primitive's center if it has been translated.
 
@@ -776,8 +776,8 @@
  <tr><td>Normal Vector</td><td>N/A</td><td>\ref helios::Context::getPrimitiveNormal( uint ) const</td></tr>
  <tr><td>Vertex Coordinates (x,y,z)</td><td>N/A</td><td>\ref helios::Context::getPrimitiveVertices( uint ) const</td></tr>
  <tr><td>Parent Object ID</td><td>N/A</td><td>\ref helios::Context::getPrimitiveParentObjectID( uint ) const</td></tr>
- <tr><td>Diffuse R-G-B color code</td><td><ul><li>\ref helios::Context::setPrimitiveColor( uint, const helios::RGBcolor& )</li><li>\ref helios::Context::setPrimitiveColor( const std::vector<uint>&, const helios::RGBcolor& )</li></ul></td><td>\ref helios::Context::getPrimitiveColor( uint ) const</td></tr>
- <tr><td>Diffuse R-G-B-A color code</td><td><ul><li>\ref helios::Context::setPrimitiveColor( uint, const helios::RGBAcolor& )</li><li>\ref helios::Context::setPrimitiveColor( const std::vector<uint>&, const helios::RGBAcolor& )</li></td><td>\ref helios::Context::getPrimitiveColorRGBA( uint ) const</td></tr>
+ <tr><td>Diffuse R-G-B color code</td><td><ul><li>\ref helios::Context::setPrimitiveColor( uint, const helios::RGBcolor& ) const</li><li>\ref helios::Context::setPrimitiveColor( const std::vector<uint>&, const helios::RGBcolor& ) const</li></ul></td><td>\ref helios::Context::getPrimitiveColor( uint ) const</td></tr>
+ <tr><td>Diffuse R-G-B-A color code</td><td><ul><li>\ref helios::Context::setPrimitiveColor( uint, const helios::RGBAcolor& ) const</li><li>\ref helios::Context::setPrimitiveColor( const std::vector<uint>&, const helios::RGBAcolor& ) const</li></td><td>\ref helios::Context::getPrimitiveColorRGBA( uint ) const</td></tr>
  <tr><td>Affine Transformation Matrix</td><td><ul><li>\ref helios::Context::setPrimitiveTransformationMatrix( uint, float (&)[16] )</li><li>\ref helios::Context::setPrimitiveTransformationMatrix( const std::vector<uint>&, float (&)[16] )</li></ul></td><td>\ref helios::Context::getPrimitiveTransformationMatrix( uint, float (&)[16] ) const</td></tr>
  </table>
  
@@ -1626,7 +1626,7 @@
 
   \section XMLread Reading XML Files
 
-  XML files can be read by the Context via the function \ref Context::loadXML().  This function parses the XML file and adds all specified structures (see above) to the Context. Below is an example of how to load an XML file into the Context.
+ XML files can be read by the Context via the function \ref helios::Context::loadXML().  This function parses the XML file and adds all specified structures (see above) to the Context. Below is an example of how to load an XML file into the Context.
   ~~~~~~{.cpp}
    #include "Context.h"
    using namespace helios;
@@ -1644,7 +1644,7 @@
 	
   \subsection PLYread Reading PLY (Stanford Polygon) Files
 
-  The Context can automatically import Stanford .ply files <a href="https://en.wikipedia.org/wiki/PLY_(file_format)">en.wikipedia.org/wiki/PLY_(file_format)</a>.  This is accomplished via the \ref loadPLY() command, as illustrated below. There are several overloaded versions of this function, which allow for various modifications to the PLY model.
+  The Context can automatically import Stanford .ply files <a href="https://en.wikipedia.org/wiki/PLY_(file_format)">en.wikipedia.org/wiki/PLY_(file_format)</a>.  This is accomplished via the \ref helios::Context::loadPLY() command, as illustrated below. There are several overloaded versions of this function, which allow for various modifications to the PLY model.
 
   ~~~~~~{.cpp}
    #include "Context.h"
@@ -1718,7 +1718,7 @@
 
   \subsection PLYwrite Writing PLY (Stanford Polygon) Files
 
-  The Context has analogous files for writing PLY files based on the geometry currently loaded in the Context. This is accomplished via the \ref writePLY() command, as illustrated below.
+  The Context has analogous files for writing PLY files based on the geometry currently loaded in the Context. This is accomplished via the \ref helios::Context::writePLY() command, as illustrated below.
 
   ~~~~~~{.cpp}
    #include "Context.h"
@@ -1757,7 +1757,7 @@
 
   \section Export Exporting Project to XML File Format
 
-  All geometry and global/primitive data loaded into the Context can be written to an XML file using the \ref Context::writeXML() function, which can be later read back in using the \ref Context::loadXML(). This functionality can be used to save progress during a simulation run, or to ensure that consistent geometry is always used across simulation runs, among other things.
+ All geometry and global/primitive data loaded into the Context can be written to an XML file using the \ref helios::Context::writeXML() function, which can be later read back in using the \ref helios::Context::loadXML(). This functionality can be used to save progress during a simulation run, or to ensure that consistent geometry is always used across simulation runs, among other things.
 
   An XML file can be written as follows:
 

--- a/plugins/plantarchitecture/doc/PlantArchitecture.dox
+++ b/plugins/plantarchitecture/doc/PlantArchitecture.dox
@@ -257,7 +257,7 @@ The coordinate system of plant organs is defined with respect to it's parent ele
 
 Nearly all parameters in the architectural model can either be specified as a constant value, or as a random variable following several pre-defined distributions.
 
-Parameters that can be randomized have type of \ref RandomParameter_float or \ref RandomParameter_int depending on the parameter value type. If the parameters are assigned a constant value, they are set the same as a regular float or int. The \ref RandomParameter_float::val "val()" method is used to get the value of the parameter.
+Parameters that can be randomized have type of \ref RandomParameter_float or \ref RandomParameter_int depending on the parameter value type. If the parameters are assigned a constant value, they are set the same as a regular float or int. The \ref RandomParameter_float::val() "val()" method is used to get the value of the parameter.
 
 ~~~~~~
 // Assign a constant value
@@ -281,16 +281,16 @@ Available distributions for \ref RandomParameter_float are listed below
 
 | Distribution | Method | Parameters |
 | ------| ------ | ------ |
-| Uniform | \ref RandomParameter_float::uniformDistribution "uniformDistribution()" | minimum value, maximum value |
-| Normal | \ref RandomParameter_float::normalDistribution "normalDistribution()" | mean, standard deviation |
-| Weibull | \ref RandomParameter_float::weibullDistribution "weibullDistribution()" | shape parameter, scale parameter |
+| Uniform | \ref RandomParameter_float::uniformDistribution() "uniformDistribution()" | minimum value, maximum value |
+| Normal | \ref RandomParameter_float::normalDistribution() "normalDistribution()" | mean, standard deviation |
+| Weibull | \ref RandomParameter_float::weibullDistribution() "weibullDistribution()" | shape parameter, scale parameter |
 
 and for \ref RandomParameter_int are:
 
 | Distribution | Method | Parameters |
 | ------| ------ | ------ |
-| Uniform | \ref RandomParameter_float::uniformDistribution "uniformDistribution()" | minimum value, maximum value |
-| Discrete Values | \ref RandomParameter_int::discreteValues "discreteValues()" | vector of discrete int values that will be randomly chosen |
+| Uniform | \ref RandomParameter_float::uniformDistribution() "uniformDistribution()" | minimum value, maximum value |
+| Discrete Values | \ref RandomParameter_int::discreteValues() "discreteValues()" | vector of discrete int values that will be randomly chosen |
 
 \section PlantArchPhytomerParams Defining the Phytomer and its Parameters
 
@@ -389,7 +389,7 @@ Flower and fruit OBJ models are usually created in 3rd party software and export
 
 \subsubsection LeafPrototypes Leaf Prototypes
 
-Leaf prototypes can be generated using three primary methods: 1) using the built-in function for procedural leaf generation based on a set of parameters, 2) loading a leaf model from an OBJ file, or 3) creating a leaf manually through Helios Context methods (e.g., \ref Context::addTileObject()).
+Leaf prototypes can be generated using three primary methods: 1) using the built-in function for procedural leaf generation based on a set of parameters, 2) loading a leaf model from an OBJ file, or 3) creating a leaf manually through Helios Context methods (e.g., \ref helios::Context::addTileObject( const helios::vec3&, const helios::vec2&, const helios::SphericalCoord&, const helios::int2& ) ).
 
 The built-in function for procedural leaf generation generates leaf geometries based on the parameter set given in the table below. The advantage of this approach is that it provides a straight-forward means of representing many leaf morphologies with random variation. The drawback is that if very high leaf detail is needed such as venation patterns, this may require using an OBJ model.
 

--- a/plugins/projectbuilder/doc/ProjectBuilder.dox
+++ b/plugins/projectbuilder/doc/ProjectBuilder.dox
@@ -88,7 +88,7 @@
         return 0;
     }
     ~~~~~~
-    It is also possible to build a project from an input XML file without opening the GUI using the \ref ProjectBuilder::build() method. The GUI can be opened later in the code after the project is built using the \ref ProjectBuilder::visualize() method.
+ It is also possible to build a project from an input XML file without opening the GUI using the \ref ProjectBuilder::buildFromXML() method. The GUI can be opened later in the code after the project is built using the \ref ProjectBuilder::visualize() method.
     ~~~~~~
     #include "ProjectBuilder.h"
 
@@ -96,7 +96,7 @@
 
         ProjectBuilder builder;
 
-        builder.build("inputs.xml");
+         builder.buildFromXML("inputs.xml");
 
         ...
 

--- a/plugins/radiation/doc/Radiation.dox
+++ b/plugins/radiation/doc/Radiation.dox
@@ -489,7 +489,7 @@ If you are using a PC, it is likely you will need to increase the GPU timeout in
  radiationmodel.enforcePeriodicBoundary("xy"); //enforce periodic boundaries in horizontal
  ~~~~~~
 
- Note that it is very important that no primitives extend laterally beyond the ground surface, otherwise the periodic boundary will lie beyond the lateral extent of the ground and there will potentially be ambient radiation that enters the domain from below. If there is a chance that primitives may laterally extend beyond the ground, it is recommended to use the \ref Context::cropDomain() function to crop the domain in the horizontal to the size of the ground.
+Note that it is very important that no primitives extend laterally beyond the ground surface, otherwise the periodic boundary will lie beyond the lateral extent of the ground and there will potentially be ambient radiation that enters the domain from below. If there is a chance that primitives may laterally extend beyond the ground, it is recommended to use the \ref helios::Context::cropDomain() function to crop the domain in the horizontal to the size of the ground.
 
  ~~~~~~{.cpp}
  vec2 ground_size(10,10);  //lateral size of the ground
@@ -576,7 +576,7 @@ If you are using a PC, it is likely you will need to increase the GPU timeout in
  radiationmodel.addRadiationCamera("visible", {"red","green","blue"}, camera_position, camera_lookat, properties, antialiasing_samples );
  ~~~~~~
 
- This will add a 3-band RGB camera, and assumes that radiation bands with labels "red", "green", and "blue" have been added based on a call to \ref RadiationModel::addBand().
+This will add a 3-band RGB camera, and assumes that radiation bands with labels "red", "green", and "blue" have been added based on a call to \ref RadiationModel::addRadiationBand().
 
  \subsubsection RadCamSpecular Radiation Camera Specular Reflection
 
@@ -650,7 +650,7 @@ If you are using a PC, it is likely you will need to increase the GPU timeout in
 
  3\. Set up the scene in Helios based on the geometry, radiative conditions, and camera(s) that will be present in the simulations. You must specify the spectral distribution of any radiation sources using \ref RadiationModel::setSourceSpectrum(), and specify an initial guess for the camera channel spectral distribution(s) using \ref RadiationModel::setCameraSpectralResponse().
 
- 4\. Add a simulated color calibration board to the scene. You can add the default color board (DGK Color Tools DKK Color Calibration Chart) using the method \ref CameraCalibration::addDefaultColorboard(), or a custom color board \ref CameraCalibration::addCustomColorboard().
+4\. Add a simulated color calibration board to the scene. You can add the default color board (DGK Color Tools DKK Color Calibration Chart) using the method \ref CameraCalibration::addDefaultColorboard(), or a custom color board \ref helios::CameraCalibration::addCustomColorboard().
 
  \subsection RadRun Running Simulations
 
@@ -818,7 +818,7 @@ If you are using a PC, it is likely you will need to increase the GPU timeout in
   std::cout << "Fraction of intercepted PAR is " << fPAR << std::endl;
  ~~~~~~
 
- The above example assumes that we have already added some geometry to the Context, separated leaf and ground UUIDs, and declared and set up the radiation model. For a full example, see \ref radiation_basics "Tutorial 10".
+The above example assumes that we have already added some geometry to the Context, separated leaf and ground UUIDs, and declared and set up the radiation model. For a full example, see \ref radiation_basics_tutorial "Tutorial 10".
 
  \subsubsection RadCamOut Writing Camera Images to File
 

--- a/plugins/visualizer/doc/Visualizer.dox
+++ b/plugins/visualizer/doc/Visualizer.dox
@@ -124,7 +124,7 @@
 
   \subsection Background Window background
 
-  The window background can be set to a constant color via the command \ref Visualizer::setBackgroundColor( RGBcolor color ) "setBackgroundColor( RGBcolor color )".  Alternatively, a three-dimensional `sky' background can be set using the \ref Visualizer::addSkyDomeByCenter "addSkyDomeByCenter" command.  This adds a hemispherical dome with a sky texture image mapped to its surface.  The default sky texture is `SkyDome_clouds.jpg' located in the plugins/visualizer/textures directory.  The following example shows how to add a sky dome:
+ The window background can be set to a constant color via the command \ref Visualizer::setBackgroundColor( const helios::RGBcolor & ) "setBackgroundColor( RGBcolor color )".  Alternatively, a three-dimensional `sky' background can be set using the \ref Visualizer::addSkyDomeByCenter "addSkyDomeByCenter" command.  This adds a hemispherical dome with a sky texture image mapped to its surface.  The default sky texture is `SkyDome_clouds.jpg' located in the plugins/visualizer/textures directory.  The following example shows how to add a sky dome:
 
   ~~~~~~{.cpp}
    #include "Visualizer.h"
@@ -229,7 +229,7 @@
 
   \subsubsection ContextGeom Automatically importing Context geometry
 
-  The visualizer can automatically import some or all geometry from the Context.  This is accomplished using the \ref buildContextGeometry command.  To add all primitives in the Context, the \ref buildContextGeometry command would be issued, which is passed the Context. We can add a subset of the Context geometry through an additional argument which takes a vector of UUID's.
+ The visualizer can automatically import some or all geometry from the Context.  This is accomplished using the \ref Visualizer::buildContextGeometry() command.  To add all primitives in the Context, the \ref Visualizer::buildContextGeometry() command would be issued, which is passed the Context. We can add a subset of the Context geometry through an additional argument which takes a vector of UUID's.
 
  <table>
    <tr>	
@@ -273,7 +273,7 @@
 
   \subsubsection PlotInteractive plotInteractive()
 
-  The \ref plotInteractive() function can be used to generate an interactive plot of the geometry in the %Visualizer.  This means that the code will pause to produce the plot/visualization until the window is closed by the user.  The user can interact with the plot by issuing keystrokes to, e.g., zoom.  An example is given below to generate an interactive plot.
+ The \ref Visualizer::plotInteractive() function can be used to generate an interactive plot of the geometry in the %Visualizer.  This means that the code will pause to produce the plot/visualization until the window is closed by the user.  The user can interact with the plot by issuing keystrokes to, e.g., zoom.  An example is given below to generate an interactive plot.
 
   ~~~~~~{.cpp}
    #include "Context.h"
@@ -364,7 +364,7 @@
   
   \subsubsection PlotUpdate plotUpdate()
 
-   The \ref plotUpdate() function simply updates the plot window based on current geometry, and continues on to the next lines of code.  This can be useful if only a still image is to be written to file, as illustrated below.
+   The \ref Visualizer::plotUpdate() function simply updates the plot window based on current geometry, and continues on to the next lines of code.  This can be useful if only a still image is to be written to file, as illustrated below.
 
   ~~~~~~{.cpp}
    #include "Context.h"
@@ -440,7 +440,7 @@
    </tr>
  </table>
 
-  The colormap to be used is set using the following command \ref setColormap( Ctable colormap_name ), where `colormap_name' is one of the enumerations in the table above.  For example, to set the `hot' colormap one would use:
+ The colormap to be used is set using the following command \ref Visualizer::setColormap( Ctable colormap_name ) "setColormap( Ctable colormap_name )", where `colormap_name' is one of the enumerations in the table above.  For example, to set the `hot' colormap one would use:
 
   ~~~~~~{.cpp}
    vis.setColormap( Visualizer::COLORMAP_HOT );
@@ -597,9 +597,9 @@
 
   The default camera position is at an elevation angle of 20 degrees and to the North, with the camera looking toward the origin.  The distance of the camera from the origin is automatically adjusted to fit all primitives in view.
 
-  There are multiple ways of specifying custom camera views.  One method involves specifying the (x,y,z) position of the camera, and the (x,y,z) position that the camera is looking at. This is accomplished using the command \ref Visualizer::setCameraPosition( vec3 cameraPosition, vec3 lookAt ) "setCameraPosition( vec3 cameraPosition, vec3 lookAt )".
+ There are multiple ways of specifying custom camera views.  One method involves specifying the (x,y,z) position of the camera, and the (x,y,z) position that the camera is looking at. This is accomplished using the command \ref Visualizer::setCameraPosition( const helios::vec3 &cameraPosition, const helios::vec3 &lookAt ) "setCameraPosition( vec3 cameraPosition, vec3 lookAt )".
 
-  The other method involves specifying the spherical coordinates of the camera with respect to the (x,y,z) position the camera is looking at.  This is accomplished using the \ref Visualizer::setCameraPosition( SphericalCoord cameraAngle, vec3 lookAt ) "setCameraPosition( SphericalCoord cameraAngle, vec3 lookAt )".
+ The other method involves specifying the spherical coordinates of the camera with respect to the (x,y,z) position the camera is looking at.  This is accomplished using the \ref Visualizer::setCameraPosition( const helios::SphericalCoord &cameraAngle, const helios::vec3 &lookAt ) "setCameraPosition( SphericalCoord cameraAngle, vec3 lookAt )".
 
   \image html CameraSchematic.jpeg
 


### PR DESCRIPTION
## Summary
- update doc references for namespaces and overloads
- link to correct tutorial anchors
- clarify example method names

## Testing
- `doxygen doc/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_68584ae26d38832cb9243663e73af29b