### PR TITLE
Fix Visualizer::clearColor behavior

### DIFF
--- a/plugins/visualizer/include/Visualizer.h
+++ b/plugins/visualizer/include/Visualizer.h
@@ -1128,6 +1128,9 @@ private:
     //! x- and y- dimensions of colorbar in normalized window coordinates
     helios::vec2 colorbar_size;
 
+    //! UUIDs associated with the current colorbar geometry
+    std::vector<size_t> colorbar_IDs;
+
     //! Buffer objects to hold per-vertex data
     std::vector<GLuint> face_index_buffer, vertex_buffer, uv_buffer;
     //! Buffer objects to hold per-primitive data. We will use textures to hold this data.

--- a/plugins/visualizer/src/Visualizer.cpp
+++ b/plugins/visualizer/src/Visualizer.cpp
@@ -449,6 +449,7 @@ void Visualizer::initialize(uint window_width_pixels, uint window_height_pixels,
 
     colorbar_position = make_vec3(0.65, 0.1, 0.1);
     colorbar_size = make_vec2(0.15, 0.1);
+    colorbar_IDs.clear();
 
     point_width = 1;
 
@@ -2010,6 +2011,10 @@ void Visualizer::enableColorbar() {
 }
 
 void Visualizer::disableColorbar() {
+    if (!colorbar_IDs.empty()) {
+        geometry_handler.deleteGeometry(colorbar_IDs);
+        colorbar_IDs.clear();
+    }
     colorbar_flag = 1;
 }
 
@@ -2743,7 +2748,11 @@ std::vector<helios::vec3> Visualizer::plotInteractive() {
 
     //Update
     if (colorbar_flag == 2) {
-        addColorbarByCenter(colorbar_title.c_str(), colorbar_size, colorbar_position, colorbar_fontcolor, colormap_current);
+        if (!colorbar_IDs.empty()) {
+            geometry_handler.deleteGeometry(colorbar_IDs);
+            colorbar_IDs.clear();
+        }
+        colorbar_IDs = addColorbarByCenter(colorbar_title.c_str(), colorbar_size, colorbar_position, colorbar_fontcolor, colormap_current);
     }
 
 
@@ -3291,7 +3300,11 @@ void Visualizer::plotUpdate(bool hide_window) {
 
     //Update
     if (colorbar_flag == 2) {
-        addColorbarByCenter(colorbar_title.c_str(), colorbar_size, colorbar_position, colorbar_fontcolor, colormap_current);
+        if (!colorbar_IDs.empty()) {
+            geometry_handler.deleteGeometry(colorbar_IDs);
+            colorbar_IDs.clear();
+        }
+        colorbar_IDs = addColorbarByCenter(colorbar_title.c_str(), colorbar_size, colorbar_position, colorbar_fontcolor, colormap_current);
     }
 
     //Watermark
@@ -4141,6 +4154,17 @@ uint Visualizer::getDepthTexture() const {
 
 void Visualizer::clearColor() {
     colorPrimitivesByData = "";
+    colorPrimitivesByObjectData = "";
+    if (!colorPrimitives_UUIDs.empty()) {
+        colorPrimitives_UUIDs.clear();
+    }
+    if (!colorPrimitives_objIDs.empty()) {
+        colorPrimitives_objIDs.clear();
+    }
+    disableColorbar();
+    colorbar_min = 0;
+    colorbar_max = 0;
+    colorbar_flag = 0;
 }
 
 std::string errorString(GLenum err) {


### PR DESCRIPTION
## Summary
- track colorbar geometry IDs
- delete colorbar geometry when disabling the colorbar
- reset colorbar range when clearing colors
- update plotting routines to avoid duplicate colorbars

## Testing
- `clang-format --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868423e660c832c87d265ac00984a01