### PR TITLE
Improve color update efficiency

### DIFF
--- a/plugins/visualizer/include/Visualizer.h
+++ b/plugins/visualizer/include/Visualizer.h
@@ -1175,6 +1175,9 @@ private:
     //! Function to actually update Context geometry (if needed), which is called by the visualizer before plotting
     void buildContextGeometry_private();
 
+    //! Update only the color data for Context primitives
+    void updateContextPrimitiveColors();
+
     float colorbar_min;
     float colorbar_max;
     std::vector<float> colorbar_ticks;


### PR DESCRIPTION
## Summary
- add `Visualizer::updateContextPrimitiveColors` helper
- use new helper when only color changes
- update build step to skip unnecessary geometry rebuilds

## Testing
- `doxygen doc/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_686a79fa9c34832c8674878ccfb5e4dc