### PR TITLE
Fix Windows path handling

### DIFF
--- a/core/src/Context_fileIO.cpp
+++ b/core/src/Context_fileIO.cpp
@@ -3936,7 +3936,8 @@ void Context::writeOBJ(const std::string &filename, const std::vector<uint> &UUI
         mtlfilename.append(".mtl");
     } else {
         if (!file_path.empty()) {
-            mtlfilename = file_path + "/" + file_stem + ".mtl";
+            std::filesystem::path mtl_path = std::filesystem::path(file_path) / (file_stem + ".mtl");
+            mtlfilename = mtl_path.string();
         } else {
             mtlfilename = file_stem + ".mtl";
         }
@@ -4119,12 +4120,12 @@ void Context::writeOBJ(const std::string &filename, const std::vector<uint> &UUI
     }
 
     // copy material textures to new directory and edit old file paths
-    std::string texture_dir = std::string(file_path);
+    std::filesystem::path texture_dir = std::filesystem::path(file_path);
     for (auto &material: materials) {
         std::string texture = material.texture;
         if (!texture.empty() && std::filesystem::exists(texture)) {
             auto file = std::filesystem::path(texture).filename();
-            std::filesystem::copy_file(texture, texture_dir + file.string(), std::filesystem::copy_options::overwrite_existing);
+            std::filesystem::copy_file(texture, texture_dir / file, std::filesystem::copy_options::overwrite_existing);
             material.texture = file.string();
         }
     }
@@ -4250,7 +4251,8 @@ void Context::writeOBJ(const std::string &filename, const std::vector<uint> &UUI
 
 
         for (const std::string &label: primitive_dat_fields) {
-            std::string datfilename = file_path + file_stem + "_" + std::string(label) + ".dat";
+            std::filesystem::path dat_path = std::filesystem::path(file_path) / (file_stem + "_" + std::string(label) + ".dat");
+            std::string datfilename = dat_path.string();
             std::ofstream datout(datfilename);
 
             for (int mat = 0; mat < materials.size(); mat++) {

--- a/core/src/global.cpp
+++ b/core/src/global.cpp
@@ -2165,14 +2165,15 @@ std::string helios::getFileName(const std::string &filepath) {
 
 std::string helios::getFilePath(const std::string &filepath, bool trailingslash) {
     std::filesystem::path output_path_fs = filepath;
-    std::string output_path = output_path_fs.parent_path().string();
-    if (trailingslash) {
-        if (output_path.find_last_of('/') != output_path.length() - 1) {
-            output_path += "/";
+    std::filesystem::path output_path = output_path_fs.parent_path();
+    std::string out_str = output_path.make_preferred().string();
+    if (trailingslash && !out_str.empty()) {
+        char last = out_str.back();
+        if (last != '/' && last != '\\') {
+            out_str += std::filesystem::path::preferred_separator;
         }
     }
-
-    return output_path;
+    return out_str;
 }
 
 bool helios::validateOutputPath(std::string &output_path, const std::vector<std::string> &allowable_file_extensions) {
@@ -2184,13 +2185,16 @@ bool helios::validateOutputPath(std::string &output_path, const std::vector<std:
 
     std::string output_file = output_path_fs.filename().string();
     std::string output_file_ext = output_path_fs.extension().string();
-    std::string output_dir = output_path_fs.parent_path().string();
+    std::string output_dir = output_path_fs.parent_path().make_preferred().string();
 
     if (output_file.empty()) { //path was a directory without a file
 
         // Make sure directory has a trailing slash
-        if (output_dir.find_last_of('/') != output_dir.length() - 1) {
-            output_path += "/";
+        if (!output_dir.empty()) {
+            char last = output_dir.back();
+            if (last != '/' && last != '\\') {
+                output_path += std::filesystem::path::preferred_separator;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- normalize path separators and add trailing slashes using `std::filesystem`
- use `std::filesystem::path` joins in OBJ export

## Testing
- `cmake ../samples/context_selftest`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_686a7c0c0df0832c99e4b45bb46c143c