### PR TITLE
Refactor plugin cmake files

### DIFF
--- a/plugins/aeriallidar/CMakeLists.txt
+++ b/plugins/aeriallidar/CMakeLists.txt
@@ -1,11 +1,7 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-include_directories(../visualizer/include)
-include_directories(../visualizer/lib/glm)
 
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
@@ -35,11 +31,23 @@ SET( CUDA_PROPAGATE_HOST_FLAGS OFF )
 
 CUDA_ADD_LIBRARY( aeriallidar STATIC "src/AerialLiDAR.cu" "src/AerialLiDAR.cpp" "src/fileIO.cpp" "src/selfTest.cpp" "../../core/src/pugixml.cpp" )
 
-include_directories("${CUDA_INCLUDE_DIRS}")
-target_link_libraries( aeriallidar ${CUDA_LIBRARIES} )
+target_include_directories(aeriallidar
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/lib/glm
+        ${CUDA_INCLUDE_DIRS}
+)
+
+target_link_libraries( aeriallidar
+    PRIVATE
+        helios
+        ${CUDA_LIBRARIES}
+        visualizer
+)
 
 #add_subdirectory( ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/ "plugins/visualizer" )
-target_link_libraries( aeriallidar visualizer )
 add_dependencies( aeriallidar visualizer )
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${CUDA_INCLUDE_DIRS};${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )

--- a/plugins/boundarylayerconductance/CMakeLists.txt
+++ b/plugins/boundarylayerconductance/CMakeLists.txt
@@ -1,11 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-
 add_library( boundarylayerconductance STATIC "src/BoundaryLayerConductanceModel.cpp" )
+
+target_include_directories(boundarylayerconductance
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(boundarylayerconductance PRIVATE helios)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 

--- a/plugins/canopygenerator/CMakeLists.txt
+++ b/plugins/canopygenerator/CMakeLists.txt
@@ -1,11 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-
 add_library( canopygenerator STATIC "src/CanopyGenerator.cpp;src/grapevine.cpp;src/whitespruce.cpp;src/tomato.cpp;src/strawberry.cpp;src/walnut.cpp;src/sorghum.cpp;src/bean.cpp")
+
+target_include_directories(canopygenerator
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(canopygenerator PRIVATE helios)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 

--- a/plugins/energybalance/CMakeLists.txt
+++ b/plugins/energybalance/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 project(helios)
 
-include_directories(include)
-include_directories(../../core/include)
 
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
@@ -34,7 +32,17 @@ SET( CUDA_PROPAGATE_HOST_FLAGS OFF )
 
 CUDA_ADD_LIBRARY( energybalance STATIC "src/EnergyBalanceModel.cpp" "src/EnergyBalanceModel.cu" "src/selfTest.cpp" )
 
-include_directories("${CUDA_INCLUDE_DIRS}")
-target_link_libraries( energybalance ${CUDA_LIBRARIES} )
+target_include_directories(energybalance
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+        ${CUDA_INCLUDE_DIRS}
+)
+
+target_link_libraries( energybalance
+    PRIVATE
+        helios
+        ${CUDA_LIBRARIES}
+)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${CUDA_INCLUDE_DIRS};${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )

--- a/plugins/leafoptics/CMakeLists.txt
+++ b/plugins/leafoptics/CMakeLists.txt
@@ -1,11 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-
 add_library( leafoptics STATIC "src/LeafOptics.cpp" )
+
+target_include_directories(leafoptics
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(leafoptics PRIVATE helios)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 

--- a/plugins/lidar/CMakeLists.txt
+++ b/plugins/lidar/CMakeLists.txt
@@ -1,11 +1,7 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-include_directories(../visualizer/include)
-include_directories(../visualizer/lib/glm)
 
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
@@ -37,12 +33,24 @@ SET( CUDA_PROPAGATE_HOST_FLAGS OFF )
 
 CUDA_ADD_LIBRARY( lidar STATIC "src/LiDAR.cu" "src/LiDAR.cpp" "src/fileIO.cpp" "src/selfTest.cpp" "../../core/src/pugixml.cpp" "lib/s_hull_pro/s_hull_pro.cpp" )
 
-include_directories("${CUDA_INCLUDE_DIRS}")
-include_directories("lib/s_hull_pro")
-target_link_libraries( lidar ${CUDA_LIBRARIES} )
+target_include_directories(lidar
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/lib/glm
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/s_hull_pro
+        ${CUDA_INCLUDE_DIRS}
+)
+
+target_link_libraries( lidar
+    PRIVATE
+        helios
+        ${CUDA_LIBRARIES}
+        visualizer
+)
 
 #add_subdirectory( ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/ "plugins/visualizer" )
-target_link_libraries( lidar visualizer )
 add_dependencies( lidar visualizer )
 
 #add_subdirectory( "${CMAKE_CURRENT_SOURCE_DIR}/lib/laszip" )

--- a/plugins/photosynthesis/CMakeLists.txt
+++ b/plugins/photosynthesis/CMakeLists.txt
@@ -1,11 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-
 add_library( photosynthesis STATIC "src/PhotosynthesisModel.cpp" )
+
+target_include_directories(photosynthesis
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(photosynthesis PRIVATE helios)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 

--- a/plugins/planthydraulics/CMakeLists.txt
+++ b/plugins/planthydraulics/CMakeLists.txt
@@ -1,10 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)
 
-include_directories(include)
-include_directories(../../core/include)
 
 add_library(planthydraulics STATIC "src/PlantHydraulicsModel.cpp" "src/selfTest.cpp")
+
+target_include_directories(planthydraulics
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(planthydraulics PRIVATE helios)
 
 set(PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE)

--- a/plugins/radiation/CMakeLists.txt
+++ b/plugins/radiation/CMakeLists.txt
@@ -1,9 +1,7 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)
 
-include_directories(include)
-include_directories(../../core/include)
 
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
@@ -13,10 +11,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Mo
 
 add_library(radiation STATIC "src/RadiationModel.cpp;src/selfTest.cpp;src/CameraCalibration.cpp;")
 
+target_include_directories(radiation
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
 find_package(CUDA REQUIRED)
 if(CUDA_FOUND)
-	include_directories(${CUDA_INCLUDE_DIRS})
-	target_link_libraries( radiation ${CUDA_LIBRARIES} )
+        target_include_directories(radiation PUBLIC ${CUDA_INCLUDE_DIRS})
+        target_link_libraries( radiation PRIVATE helios ${CUDA_LIBRARIES} )
 endif(CUDA_FOUND)
 
 if(UNIX AND NOT APPLE)
@@ -27,15 +31,15 @@ if(UNIX AND NOT APPLE)
 		set(OPTIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/OptiX/linux64-6.5.0/)
 		message("Using OptiX version 6.5")
 	endif()
-	include_directories(${OPTIX_PATH}include)
-	add_subdirectory(${OPTIX_PATH} "plugins/radiation")	
-	target_link_libraries( radiation ${OPTIX_PATH}lib64/liboptix.so )
+        target_include_directories(radiation PUBLIC ${OPTIX_PATH}include)
+        add_subdirectory(${OPTIX_PATH} "plugins/radiation")
+        target_link_libraries( radiation ${OPTIX_PATH}lib64/liboptix.so )
 endif(UNIX AND NOT APPLE)
 if(APPLE)
 	set(OPTIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/OptiX/mac64-4.0.2/)
-	include_directories(${OPTIX_PATH}include)
-	add_subdirectory(${OPTIX_PATH})
-	target_link_libraries( radiation ${OPTIX_PATH}lib64/liboptix.dylib )
+        target_include_directories(radiation PUBLIC ${OPTIX_PATH}include)
+        add_subdirectory(${OPTIX_PATH})
+        target_link_libraries( radiation ${OPTIX_PATH}lib64/liboptix.dylib )
 endif(APPLE)
 if(WIN32)
 	if( OPTIX_VERSION_LEGACY )
@@ -49,8 +53,8 @@ if(WIN32)
 		set(OPTIX_DLL "optix.6.5.0.dll")
 		message("Using OptiX version 6.5")
 	endif()
-	include_directories(${OPTIX_PATH}include)
-	target_link_libraries( radiation "${OPTIX_PATH}lib64/${OPTIX_LIB}" )
+        target_include_directories(radiation PUBLIC ${OPTIX_PATH}include)
+        target_link_libraries( radiation "${OPTIX_PATH}lib64/${OPTIX_LIB}" )
 	add_custom_command( TARGET radiation POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${OPTIX_PATH}lib64/${OPTIX_LIB}" "${CMAKE_BINARY_DIR}/." )
 	add_custom_command( TARGET radiation POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${OPTIX_PATH}bin64/${OPTIX_DLL}" "${CMAKE_BINARY_DIR}/." )
 

--- a/plugins/solarposition/CMakeLists.txt
+++ b/plugins/solarposition/CMakeLists.txt
@@ -1,11 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-
 add_library( solarposition STATIC "src/SolarPosition.cpp" "src/selfTest.cpp" )
+
+target_include_directories(solarposition
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(solarposition PRIVATE helios)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 

--- a/plugins/stomatalconductance/CMakeLists.txt
+++ b/plugins/stomatalconductance/CMakeLists.txt
@@ -1,11 +1,16 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
-
 add_library( stomatalconductance STATIC "src/StomatalConductanceModel.cpp" )
+
+target_include_directories(stomatalconductance
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+)
+
+target_link_libraries(stomatalconductance PRIVATE helios)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 

--- a/plugins/syntheticannotation/CMakeLists.txt
+++ b/plugins/syntheticannotation/CMakeLists.txt
@@ -1,11 +1,7 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../core/include")
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/include")
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/lib/glm")
 
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
@@ -15,7 +11,15 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Mo
 
 add_library( syntheticannotation STATIC "${CMAKE_CURRENT_SOURCE_DIR}/src/SyntheticAnnotation.cpp" )
 
-target_link_libraries( syntheticannotation visualizer )
+target_include_directories(syntheticannotation
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../visualizer/lib/glm
+)
+
+target_link_libraries( syntheticannotation PRIVATE helios visualizer )
 add_dependencies( syntheticannotation visualizer )
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/lib/s_hull_pro;${CUDA_INCLUDE_DIRS};${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )

--- a/plugins/voxelintersection/CMakeLists.txt
+++ b/plugins/voxelintersection/CMakeLists.txt
@@ -1,9 +1,7 @@
-cmake_minimum_required(VERSION 2.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(helios)  
 
-include_directories(include)
-include_directories(../../core/include)
 
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
      set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
@@ -33,8 +31,18 @@ SET( CUDA_PROPAGATE_HOST_FLAGS OFF )
 
 CUDA_ADD_LIBRARY( voxelintersection STATIC "src/VoxelIntersection.cu" "src/VoxelIntersection.cpp" )
 
-include_directories("${CUDA_INCLUDE_DIRS}")
-target_link_libraries( voxelintersection ${CUDA_LIBRARIES} )
+target_include_directories(voxelintersection
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/include
+        ${CUDA_INCLUDE_DIRS}
+)
+
+target_link_libraries( voxelintersection
+    PRIVATE
+        helios
+        ${CUDA_LIBRARIES}
+)
 
 set( PLUGIN_INCLUDE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/include;${CUDA_INCLUDE_DIRS};${PLUGIN_INCLUDE_PATHS}" PARENT_SCOPE )
 


### PR DESCRIPTION
## Summary
- require CMake 3.15 for plugins that previously used version 2.0
- switch plugins to `target_include_directories`
- link plugin libraries with `target_link_libraries`

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_6873d554f3a4832cae4d75c8a7cbf31d